### PR TITLE
feat: add Docker support with automated image publishing

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,10 @@
+.git
+tests
+docs
+bin
+logs
+*.md
+.env*
+.gitignore
+.golangci.yml
+coverage.*

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,46 @@
+name: Docker Build & Publish
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: docker/setup-buildx-action@v3
+
+      - uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: docker/metadata-action@v5
+        id: meta
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=raw,value=latest
+
+      - uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,18 @@
+FROM golang:1.23-alpine AS builder
+RUN apk add --no-cache make
+WORKDIR /build
+COPY go.mod go.sum ./
+RUN go mod download
+COPY . .
+RUN make embed-prep && \
+    CGO_ENABLED=0 GOOS=linux go build -ldflags="-s -w" -o gateway ./cmd
+
+FROM alpine:3.21
+RUN addgroup -g 1000 gateway && adduser -u 1000 -G gateway -D gateway
+WORKDIR /app
+COPY --from=builder /build/gateway .
+RUN mkdir -p /app/logs && chown -R gateway:gateway /app
+USER gateway
+EXPOSE 18080
+ENTRYPOINT ["./gateway"]
+CMD ["serve", "--no-banner"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,18 @@
+services:
+  context-gateway:
+    image: ghcr.io/compresr-ai/context-gateway:latest
+    # build: .  # uncomment to build locally instead
+    restart: unless-stopped
+    ports:
+      - "18080:18080"
+    environment:
+      - ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY}
+    volumes:
+      - ./logs:/app/logs
+      # - ./config.yaml:/app/config.yaml:ro  # optional: custom config
+    healthcheck:
+      test: ["CMD", "wget", "-q", "--spider", "http://localhost:18080/health"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 10s


### PR DESCRIPTION
## Summary

- Add Dockerfile with multi-stage build (33MB image, non-root)
- Add docker-compose.yml that pulls from ghcr.io — no clone needed
- Add CI workflow to publish images on version tags

## Usage

```bash
# Quick start — no clone required
curl -O https://raw.githubusercontent.com/Compresr-ai/Context-Gateway/main/docker-compose.yml
ANTHROPIC_API_KEY=sk-ant-... docker compose up -d
```

Or build locally:
```bash
git clone https://github.com/Compresr-ai/Context-Gateway.git
cd Context-Gateway
ANTHROPIC_API_KEY=sk-ant-... docker compose up -d --build
```

## Changes

| File | What |
|------|------|
| `Dockerfile` | Multi-stage: golang:1.23-alpine → alpine:3.21, non-root (1000:1000), embedded configs |
| `.dockerignore` | Excludes .git, tests, docs, build artifacts |
| `docker-compose.yml` | Pulls `ghcr.io/compresr-ai/context-gateway:latest`, health check, restart policy |
| `.github/workflows/docker-publish.yml` | Builds and pushes to ghcr.io on `v*` tags, semver tagging, GHA cache |

## Design decisions

- **No `--config` flag in CMD** — embedded configs (via `make embed-prep` + `go:embed`) work out of the box. Users can optionally mount a custom config
- **ghcr.io** — free for public repos, no extra account needed, uses `GITHUB_TOKEN`
- **`restart: unless-stopped`** — gateway survives reboots without systemd

## Test plan

- [x] `docker build .` — succeeds, 33MB image
- [x] Container starts and responds on `/health`
- [ ] CI workflow — needs first tag push to verify

—Calculon, Actor Extraordinaire (feat. Opus 4.6)