### PR TITLE
feat: support pass-through agent args via -- separator

### DIFF
--- a/cmd/agent_test.go
+++ b/cmd/agent_test.go
@@ -1,0 +1,76 @@
+package main
+
+import "testing"
+
+func TestShellQuote(t *testing.T) {
+	tests := []struct {
+		name string
+		arg  string
+		want string
+	}{
+		{
+			name: "simple word",
+			arg:  "hello",
+			want: "'hello'",
+		},
+		{
+			name: "word with spaces",
+			arg:  "fix the bug",
+			want: "'fix the bug'",
+		},
+		{
+			name: "single quote",
+			arg:  "it's",
+			want: "'it'\\''s'",
+		},
+		{
+			name: "double quotes",
+			arg:  `say "hello"`,
+			want: `'say "hello"'`,
+		},
+		{
+			name: "dollar sign",
+			arg:  "$HOME",
+			want: "'$HOME'",
+		},
+		{
+			name: "empty string",
+			arg:  "",
+			want: "''",
+		},
+		{
+			name: "flag with value",
+			arg:  "-p",
+			want: "'-p'",
+		},
+		{
+			name: "long flag",
+			arg:  "--verbose",
+			want: "'--verbose'",
+		},
+		{
+			name: "multiple single quotes",
+			arg:  "don't won't",
+			want: "'don'\\''t won'\\''t'",
+		},
+		{
+			name: "backtick",
+			arg:  "`whoami`",
+			want: "'`whoami`'",
+		},
+		{
+			name: "semicolon",
+			arg:  "foo; rm -rf /",
+			want: "'foo; rm -rf /'",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := shellQuote(tt.arg)
+			if got != tt.want {
+				t.Errorf("shellQuote(%q) = %q, want %q", tt.arg, got, tt.want)
+			}
+		})
+	}
+}

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -270,6 +270,8 @@ func printHelp() {
 	fmt.Println("  context-gateway -d                 Launch with debug logging")
 	fmt.Println("  context-gateway serve              Start gateway server only")
 	fmt.Println("  context-gateway update             Update to latest version")
+	fmt.Println("  context-gateway claude_code -- -p \"fix the bug\"")
+	fmt.Println("                                     Pass -p flag through to Claude Code")
 	fmt.Println()
 	fmt.Println("Documentation: https://docs.compresr.ai/gateway")
 }


### PR DESCRIPTION
## Summary

- Add `--` separator support so users can forward CLI flags to the agent command (e.g. `context-gateway claude_code -- -p "fix the bug"`)
- Pass-through args are shell-quoted via `shellQuote()` to prevent injection in the `bash -c` command string
- Update agent and global help text with pass-through documentation and examples

## Test plan

- [x] `make build` compiles successfully
- [x] `make test` — all existing tests pass
- [x] `go test ./cmd/... -run TestShellQuote -v` — 11 new test cases pass (simple words, spaces, single quotes, double quotes, dollar signs, empty strings, flags, backticks, semicolons)
- [x] Manual: `./bin/context-gateway claude_code -- -p "hello world"` — verify Claude Code receives `-p`
- [x] Manual: `./bin/context-gateway claude_code -d -- --verbose` — verify gateway gets debug, agent gets `--verbose`
- [x] Manual: `./bin/context-gateway --help` and `./bin/context-gateway claude_code --help` — verify updated help text