### PR TITLE
feat: add Gemini adapter for Context Gateway

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -145,7 +145,6 @@ See `docs/slack-setup.md` for manual setup.
 ## Unimplemented (Stubs)
 
 - `internal/pipes/tool_discovery/tool_discovery.go` — Tool filtering pipe (returns original unchanged)
-- Gemini adapter — Not implemented
 
 ## Logging
 

--- a/internal/adapters/gemini.go
+++ b/internal/adapters/gemini.go
@@ -1,0 +1,319 @@
+package adapters
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+// GeminiAdapter handles Google Gemini API format requests.
+// Gemini uses a unique format with contents[]/parts[] and functionCall/functionResponse
+// objects, distinct from both OpenAI and Anthropic formats.
+//
+// Key format differences:
+//   - Tool calls: parts[].functionCall with name/args
+//   - Tool responses: parts[].functionResponse with name/response (object, not string)
+//   - Usage: usageMetadata.promptTokenCount/candidatesTokenCount/totalTokenCount
+//   - Model: in URL path (/models/{model}:generateContent), not request body
+type GeminiAdapter struct {
+	BaseAdapter
+}
+
+// NewGeminiAdapter creates a new Gemini adapter.
+func NewGeminiAdapter() *GeminiAdapter {
+	return &GeminiAdapter{
+		BaseAdapter: BaseAdapter{
+			name:     "gemini",
+			provider: ProviderGemini,
+		},
+	}
+}
+
+// =============================================================================
+// TOOL OUTPUT - Extract/Apply
+// =============================================================================
+
+// ExtractToolOutput extracts tool result content from Gemini format.
+// Gemini format: contents[] with parts containing functionResponse objects.
+//
+//	{"contents": [
+//	  {"role": "user", "parts": [{"functionResponse": {"name": "read_file", "response": {"content": "..."}}}]}
+//	]}
+func (a *GeminiAdapter) ExtractToolOutput(body []byte) ([]ExtractedContent, error) {
+	var req map[string]any
+	if err := json.Unmarshal(body, &req); err != nil {
+		return nil, fmt.Errorf("failed to parse request: %w", err)
+	}
+
+	contents, ok := req["contents"].([]any)
+	if !ok {
+		return nil, nil
+	}
+
+	// Build tool name lookup from model's functionCall parts
+	// (not strictly needed since functionResponse already has name, but kept for consistency)
+	var extracted []ExtractedContent
+	for msgIdx, contentAny := range contents {
+		content, ok := contentAny.(map[string]any)
+		if !ok {
+			continue
+		}
+
+		parts, ok := content["parts"].([]any)
+		if !ok {
+			continue
+		}
+
+		for partIdx, partAny := range parts {
+			part, ok := partAny.(map[string]any)
+			if !ok {
+				continue
+			}
+
+			fnResp, ok := part["functionResponse"].(map[string]any)
+			if !ok {
+				continue
+			}
+
+			name := getString(fnResp, "name")
+			respContent := a.extractResponseContent(fnResp["response"])
+
+			if respContent != "" {
+				extracted = append(extracted, ExtractedContent{
+					ID:           fmt.Sprintf("%d_%d", msgIdx, partIdx),
+					Content:      respContent,
+					ContentType:  "tool_result",
+					ToolName:     name,
+					MessageIndex: msgIdx,
+					BlockIndex:   partIdx,
+				})
+			}
+		}
+	}
+
+	return extracted, nil
+}
+
+// ApplyToolOutput applies compressed tool results back to the Gemini format request.
+func (a *GeminiAdapter) ApplyToolOutput(body []byte, results []CompressedResult) ([]byte, error) {
+	if len(results) == 0 {
+		return body, nil
+	}
+
+	resultMap := make(map[string]string)
+	for _, r := range results {
+		resultMap[r.ID] = r.Compressed
+	}
+
+	var req map[string]any
+	if err := json.Unmarshal(body, &req); err != nil {
+		return nil, fmt.Errorf("failed to parse request: %w", err)
+	}
+
+	contents, ok := req["contents"].([]any)
+	if !ok {
+		return body, nil
+	}
+
+	for msgIdx, contentAny := range contents {
+		content, ok := contentAny.(map[string]any)
+		if !ok {
+			continue
+		}
+
+		parts, ok := content["parts"].([]any)
+		if !ok {
+			continue
+		}
+
+		for partIdx, partAny := range parts {
+			part, ok := partAny.(map[string]any)
+			if !ok {
+				continue
+			}
+
+			fnResp, ok := part["functionResponse"].(map[string]any)
+			if !ok {
+				continue
+			}
+
+			id := fmt.Sprintf("%d_%d", msgIdx, partIdx)
+			if compressed, found := resultMap[id]; found {
+				fnResp["response"] = map[string]any{"result": compressed}
+				part["functionResponse"] = fnResp
+				parts[partIdx] = part
+			}
+		}
+
+		content["parts"] = parts
+		contents[msgIdx] = content
+	}
+
+	req["contents"] = contents
+	return json.Marshal(req)
+}
+
+// =============================================================================
+// TOOL DISCOVERY - Extract/Apply (stub)
+// =============================================================================
+
+// ExtractToolDiscovery extracts tool definitions for filtering.
+func (a *GeminiAdapter) ExtractToolDiscovery(body []byte, opts *ToolDiscoveryOptions) ([]ExtractedContent, error) {
+	return nil, nil
+}
+
+// ApplyToolDiscovery applies filtered tools back to the request.
+func (a *GeminiAdapter) ApplyToolDiscovery(body []byte, results []CompressedResult) ([]byte, error) {
+	return body, nil
+}
+
+// =============================================================================
+// QUERY EXTRACTION
+// =============================================================================
+
+// ExtractUserQuery extracts the last user message content from Gemini format.
+// Looks for contents[] with role:"user" and text parts.
+func (a *GeminiAdapter) ExtractUserQuery(body []byte) string {
+	var req map[string]any
+	if err := json.Unmarshal(body, &req); err != nil {
+		return ""
+	}
+
+	contents, ok := req["contents"].([]any)
+	if !ok {
+		return ""
+	}
+
+	// Iterate backwards to find the last user message with text content
+	for i := len(contents) - 1; i >= 0; i-- {
+		content, ok := contents[i].(map[string]any)
+		if !ok {
+			continue
+		}
+
+		if getString(content, "role") != "user" {
+			continue
+		}
+
+		parts, ok := content["parts"].([]any)
+		if !ok {
+			continue
+		}
+
+		// Look for text parts (skip functionResponse parts)
+		var texts []string
+		for _, partAny := range parts {
+			part, ok := partAny.(map[string]any)
+			if !ok {
+				continue
+			}
+			if text := getString(part, "text"); text != "" {
+				texts = append(texts, text)
+			}
+		}
+
+		if len(texts) > 0 {
+			return strings.Join(texts, "\n")
+		}
+	}
+
+	return ""
+}
+
+// =============================================================================
+// USAGE EXTRACTION
+// =============================================================================
+
+// ExtractUsage extracts token usage from Gemini API response.
+// Gemini format: {"usageMetadata": {"promptTokenCount": N, "candidatesTokenCount": N, "totalTokenCount": N}}
+func (a *GeminiAdapter) ExtractUsage(responseBody []byte) UsageInfo {
+	if len(responseBody) == 0 {
+		return UsageInfo{}
+	}
+
+	var resp struct {
+		UsageMetadata struct {
+			PromptTokenCount     int `json:"promptTokenCount"`
+			CandidatesTokenCount int `json:"candidatesTokenCount"`
+			TotalTokenCount      int `json:"totalTokenCount"`
+		} `json:"usageMetadata"`
+	}
+	if err := json.Unmarshal(responseBody, &resp); err != nil {
+		return UsageInfo{}
+	}
+
+	return UsageInfo{
+		InputTokens:  resp.UsageMetadata.PromptTokenCount,
+		OutputTokens: resp.UsageMetadata.CandidatesTokenCount,
+		TotalTokens:  resp.UsageMetadata.TotalTokenCount,
+	}
+}
+
+// =============================================================================
+// MODEL EXTRACTION
+// =============================================================================
+
+// ExtractModel extracts the model name from Gemini request body.
+// Gemini typically puts the model in the URL path (/models/{model}:generateContent),
+// not in the request body. Some clients may include a "model" field in the body.
+func (a *GeminiAdapter) ExtractModel(requestBody []byte) string {
+	if len(requestBody) == 0 {
+		return ""
+	}
+
+	var req struct {
+		Model string `json:"model"`
+	}
+	if err := json.Unmarshal(requestBody, &req); err != nil {
+		return ""
+	}
+
+	// Strip "models/" prefix if present (e.g., "models/gemini-3-flash" -> "gemini-3-flash")
+	if strings.HasPrefix(req.Model, "models/") {
+		return req.Model[len("models/"):]
+	}
+	return req.Model
+}
+
+// =============================================================================
+// HELPERS
+// =============================================================================
+
+// extractResponseContent extracts a string from a Gemini functionResponse.response value.
+// The response field is typically a JSON object, so we serialize it.
+func (a *GeminiAdapter) extractResponseContent(v any) string {
+	if v == nil {
+		return ""
+	}
+
+	// Direct string (unlikely but handle it)
+	if s, ok := v.(string); ok {
+		return s
+	}
+
+	// Object — serialize to JSON string for compression
+	if m, ok := v.(map[string]any); ok {
+		// If there's a single "result" or "content" or "output" key with a string value, use it directly
+		for _, key := range []string{"result", "content", "output"} {
+			if s, ok := m[key].(string); ok && len(m) == 1 {
+				return s
+			}
+		}
+		// Otherwise serialize the entire object
+		b, err := json.Marshal(m)
+		if err != nil {
+			return ""
+		}
+		return string(b)
+	}
+
+	// Array or other — serialize
+	b, err := json.Marshal(v)
+	if err != nil {
+		return ""
+	}
+	return string(b)
+}
+
+// Ensure GeminiAdapter implements Adapter
+var _ Adapter = (*GeminiAdapter)(nil)

--- a/internal/adapters/registry.go
+++ b/internal/adapters/registry.go
@@ -25,6 +25,7 @@ func NewRegistry() *Registry {
 	r.Register(NewOpenAIAdapter())
 	r.Register(NewBedrockAdapter())
 	r.Register(NewOllamaAdapter())
+	r.Register(NewGeminiAdapter())
 
 	return r
 }

--- a/tests/common/provider_identification_test.go
+++ b/tests/common/provider_identification_test.go
@@ -31,9 +31,9 @@ func TestProviderIdentification_ExplicitHeader(t *testing.T) {
 			expectedName: "openai",
 		},
 		{
-			name:         "X-Provider: gemini (falls back to openai - not implemented)",
+			name:         "X-Provider: gemini",
 			headerValue:  "gemini",
-			expectedName: "openai", // Falls back to OpenAI
+			expectedName: "gemini",
 		},
 		{
 			name:         "X-Provider: unknown (falls back to openai)",

--- a/tests/gemini/unit/adapter_test.go
+++ b/tests/gemini/unit/adapter_test.go
@@ -1,0 +1,419 @@
+package unit
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"github.com/compresr/context-gateway/internal/adapters"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// =============================================================================
+// BASIC ADAPTER PROPERTIES
+// =============================================================================
+
+func TestGemini_Name(t *testing.T) {
+	adapter := adapters.NewGeminiAdapter()
+	assert.Equal(t, "gemini", adapter.Name())
+}
+
+func TestGemini_Provider(t *testing.T) {
+	adapter := adapters.NewGeminiAdapter()
+	assert.Equal(t, adapters.ProviderGemini, adapter.Provider())
+}
+
+// =============================================================================
+// TOOL OUTPUT - Extract
+// =============================================================================
+
+func TestGemini_ExtractToolOutput(t *testing.T) {
+	adapter := adapters.NewGeminiAdapter()
+
+	body := []byte(`{
+		"contents": [
+			{"role": "user", "parts": [{"text": "Read the config file"}]},
+			{"role": "model", "parts": [{"functionCall": {"name": "read_file", "args": {"path": "config.yaml"}}}]},
+			{"role": "user", "parts": [{"functionResponse": {"name": "read_file", "response": {"content": "server:\n  port: 8080\n  host: localhost"}}}]}
+		]
+	}`)
+
+	extracted, err := adapter.ExtractToolOutput(body)
+
+	require.NoError(t, err)
+	require.Len(t, extracted, 1)
+	assert.Equal(t, "2_0", extracted[0].ID)
+	assert.Equal(t, "server:\n  port: 8080\n  host: localhost", extracted[0].Content)
+	assert.Equal(t, "tool_result", extracted[0].ContentType)
+	assert.Equal(t, "read_file", extracted[0].ToolName)
+	assert.Equal(t, 2, extracted[0].MessageIndex)
+	assert.Equal(t, 0, extracted[0].BlockIndex)
+}
+
+func TestGemini_ExtractToolOutput_ObjectResponse(t *testing.T) {
+	adapter := adapters.NewGeminiAdapter()
+
+	// When response has multiple fields, it should be serialized to JSON
+	body := []byte(`{
+		"contents": [
+			{"role": "model", "parts": [{"functionCall": {"name": "get_weather", "args": {}}}]},
+			{"role": "user", "parts": [{"functionResponse": {"name": "get_weather", "response": {"temperature": 72, "condition": "sunny"}}}]}
+		]
+	}`)
+
+	extracted, err := adapter.ExtractToolOutput(body)
+
+	require.NoError(t, err)
+	require.Len(t, extracted, 1)
+	assert.Equal(t, "get_weather", extracted[0].ToolName)
+	// Multi-field response is serialized to JSON
+	assert.Contains(t, extracted[0].Content, "temperature")
+	assert.Contains(t, extracted[0].Content, "sunny")
+}
+
+func TestGemini_ExtractToolOutput_MultipleTools(t *testing.T) {
+	adapter := adapters.NewGeminiAdapter()
+
+	body := []byte(`{
+		"contents": [
+			{"role": "user", "parts": [{"text": "Read both files"}]},
+			{"role": "model", "parts": [
+				{"functionCall": {"name": "read_file", "args": {"path": "a.txt"}}},
+				{"functionCall": {"name": "read_file", "args": {"path": "b.txt"}}}
+			]},
+			{"role": "user", "parts": [
+				{"functionResponse": {"name": "read_file", "response": {"content": "contents of file a"}}},
+				{"functionResponse": {"name": "read_file", "response": {"content": "contents of file b"}}}
+			]}
+		]
+	}`)
+
+	extracted, err := adapter.ExtractToolOutput(body)
+
+	require.NoError(t, err)
+	require.Len(t, extracted, 2)
+	assert.Equal(t, "2_0", extracted[0].ID)
+	assert.Equal(t, "contents of file a", extracted[0].Content)
+	assert.Equal(t, "2_1", extracted[1].ID)
+	assert.Equal(t, "contents of file b", extracted[1].Content)
+}
+
+func TestGemini_ExtractToolOutput_Empty(t *testing.T) {
+	adapter := adapters.NewGeminiAdapter()
+
+	body := []byte(`{"contents": []}`)
+
+	extracted, err := adapter.ExtractToolOutput(body)
+
+	require.NoError(t, err)
+	assert.Empty(t, extracted)
+}
+
+func TestGemini_ExtractToolOutput_NoContents(t *testing.T) {
+	adapter := adapters.NewGeminiAdapter()
+
+	body := []byte(`{}`)
+
+	extracted, err := adapter.ExtractToolOutput(body)
+
+	require.NoError(t, err)
+	assert.Nil(t, extracted)
+}
+
+func TestGemini_ExtractToolOutput_InvalidJSON(t *testing.T) {
+	adapter := adapters.NewGeminiAdapter()
+
+	_, err := adapter.ExtractToolOutput([]byte(`{invalid}`))
+
+	require.Error(t, err)
+}
+
+// =============================================================================
+// TOOL OUTPUT - Apply
+// =============================================================================
+
+func TestGemini_ApplyToolOutput(t *testing.T) {
+	adapter := adapters.NewGeminiAdapter()
+
+	body := []byte(`{
+		"contents": [
+			{"role": "user", "parts": [{"text": "Read the config"}]},
+			{"role": "model", "parts": [{"functionCall": {"name": "read_file", "args": {}}}]},
+			{"role": "user", "parts": [{"functionResponse": {"name": "read_file", "response": {"content": "original long content"}}}]}
+		]
+	}`)
+
+	results := []adapters.CompressedResult{
+		{ID: "2_0", Compressed: "compressed: config with port 8080"},
+	}
+
+	modified, err := adapter.ApplyToolOutput(body, results)
+
+	require.NoError(t, err)
+
+	var req map[string]any
+	require.NoError(t, json.Unmarshal(modified, &req))
+
+	contents := req["contents"].([]any)
+	userMsg := contents[2].(map[string]any)
+	parts := userMsg["parts"].([]any)
+	part := parts[0].(map[string]any)
+	fnResp := part["functionResponse"].(map[string]any)
+	resp := fnResp["response"].(map[string]any)
+	assert.Equal(t, "compressed: config with port 8080", resp["result"])
+}
+
+func TestGemini_ApplyToolOutput_NoResults(t *testing.T) {
+	adapter := adapters.NewGeminiAdapter()
+
+	body := []byte(`{"contents": []}`)
+
+	modified, err := adapter.ApplyToolOutput(body, nil)
+
+	require.NoError(t, err)
+	assert.Equal(t, body, modified)
+}
+
+func TestGemini_ApplyToolOutput_InvalidJSON(t *testing.T) {
+	adapter := adapters.NewGeminiAdapter()
+
+	_, err := adapter.ApplyToolOutput([]byte(`{invalid}`), []adapters.CompressedResult{{ID: "0_0", Compressed: "x"}})
+
+	require.Error(t, err)
+}
+
+// =============================================================================
+// TOOL DISCOVERY (Stub)
+// =============================================================================
+
+func TestGemini_ExtractToolDiscovery_Stub(t *testing.T) {
+	adapter := adapters.NewGeminiAdapter()
+
+	extracted, err := adapter.ExtractToolDiscovery([]byte(`{}`), nil)
+
+	require.NoError(t, err)
+	assert.Empty(t, extracted)
+}
+
+func TestGemini_ApplyToolDiscovery_Stub(t *testing.T) {
+	adapter := adapters.NewGeminiAdapter()
+
+	body := []byte(`{"contents": [], "tools": []}`)
+
+	modified, err := adapter.ApplyToolDiscovery(body, nil)
+
+	require.NoError(t, err)
+	assert.Equal(t, body, modified)
+}
+
+// =============================================================================
+// USER QUERY EXTRACTION
+// =============================================================================
+
+func TestGemini_ExtractUserQuery(t *testing.T) {
+	adapter := adapters.NewGeminiAdapter()
+
+	body := []byte(`{
+		"contents": [
+			{"role": "user", "parts": [{"text": "What is the capital of France?"}]}
+		]
+	}`)
+
+	query := adapter.ExtractUserQuery(body)
+	assert.Equal(t, "What is the capital of France?", query)
+}
+
+func TestGemini_ExtractUserQuery_MultipleMessages(t *testing.T) {
+	adapter := adapters.NewGeminiAdapter()
+
+	body := []byte(`{
+		"contents": [
+			{"role": "user", "parts": [{"text": "First question"}]},
+			{"role": "model", "parts": [{"text": "First answer"}]},
+			{"role": "user", "parts": [{"text": "Follow-up question"}]}
+		]
+	}`)
+
+	query := adapter.ExtractUserQuery(body)
+	assert.Equal(t, "Follow-up question", query, "Should return the last user message")
+}
+
+func TestGemini_ExtractUserQuery_SkipsFunctionResponseParts(t *testing.T) {
+	adapter := adapters.NewGeminiAdapter()
+
+	// The last user message contains only functionResponse, no text
+	body := []byte(`{
+		"contents": [
+			{"role": "user", "parts": [{"text": "Read the file and summarize it"}]},
+			{"role": "model", "parts": [{"functionCall": {"name": "read_file", "args": {}}}]},
+			{"role": "user", "parts": [{"functionResponse": {"name": "read_file", "response": {"content": "file data"}}}]}
+		]
+	}`)
+
+	query := adapter.ExtractUserQuery(body)
+	assert.Equal(t, "Read the file and summarize it", query, "Should skip user messages with only functionResponse parts")
+}
+
+func TestGemini_ExtractUserQuery_Empty(t *testing.T) {
+	adapter := adapters.NewGeminiAdapter()
+
+	query := adapter.ExtractUserQuery([]byte(`{"contents": []}`))
+	assert.Empty(t, query)
+}
+
+func TestGemini_ExtractUserQuery_InvalidJSON(t *testing.T) {
+	adapter := adapters.NewGeminiAdapter()
+
+	query := adapter.ExtractUserQuery([]byte(`{invalid}`))
+	assert.Empty(t, query)
+}
+
+func TestGemini_ExtractUserQuery_MultipleTextParts(t *testing.T) {
+	adapter := adapters.NewGeminiAdapter()
+
+	body := []byte(`{
+		"contents": [
+			{"role": "user", "parts": [
+				{"text": "Part one."},
+				{"text": "Part two."}
+			]}
+		]
+	}`)
+
+	query := adapter.ExtractUserQuery(body)
+	assert.Equal(t, "Part one.\nPart two.", query, "Should join multiple text parts")
+}
+
+// =============================================================================
+// USAGE EXTRACTION
+// =============================================================================
+
+func TestGemini_ExtractUsage(t *testing.T) {
+	adapter := adapters.NewGeminiAdapter()
+
+	responseBody := []byte(`{
+		"candidates": [{"content": {"parts": [{"text": "Hello!"}]}}],
+		"usageMetadata": {
+			"promptTokenCount": 150,
+			"candidatesTokenCount": 80,
+			"totalTokenCount": 230
+		}
+	}`)
+
+	usage := adapter.ExtractUsage(responseBody)
+
+	assert.Equal(t, 150, usage.InputTokens)
+	assert.Equal(t, 80, usage.OutputTokens)
+	assert.Equal(t, 230, usage.TotalTokens)
+}
+
+func TestGemini_ExtractUsage_Empty(t *testing.T) {
+	adapter := adapters.NewGeminiAdapter()
+
+	usage := adapter.ExtractUsage([]byte{})
+	assert.Equal(t, 0, usage.InputTokens)
+	assert.Equal(t, 0, usage.OutputTokens)
+	assert.Equal(t, 0, usage.TotalTokens)
+}
+
+func TestGemini_ExtractUsage_NoUsageField(t *testing.T) {
+	adapter := adapters.NewGeminiAdapter()
+
+	usage := adapter.ExtractUsage([]byte(`{"candidates": []}`))
+	assert.Equal(t, 0, usage.InputTokens)
+	assert.Equal(t, 0, usage.OutputTokens)
+	assert.Equal(t, 0, usage.TotalTokens)
+}
+
+func TestGemini_ExtractUsage_InvalidJSON(t *testing.T) {
+	adapter := adapters.NewGeminiAdapter()
+
+	usage := adapter.ExtractUsage([]byte(`{invalid}`))
+	assert.Equal(t, 0, usage.InputTokens)
+}
+
+// =============================================================================
+// MODEL EXTRACTION
+// =============================================================================
+
+func TestGemini_ExtractModel(t *testing.T) {
+	adapter := adapters.NewGeminiAdapter()
+
+	body := []byte(`{"model": "gemini-3-flash", "contents": []}`)
+	model := adapter.ExtractModel(body)
+	assert.Equal(t, "gemini-3-flash", model)
+}
+
+func TestGemini_ExtractModel_WithModelsPrefix(t *testing.T) {
+	adapter := adapters.NewGeminiAdapter()
+
+	body := []byte(`{"model": "models/gemini-2.5-pro", "contents": []}`)
+	model := adapter.ExtractModel(body)
+	assert.Equal(t, "gemini-2.5-pro", model, "Should strip models/ prefix")
+}
+
+func TestGemini_ExtractModel_Empty(t *testing.T) {
+	adapter := adapters.NewGeminiAdapter()
+
+	model := adapter.ExtractModel([]byte{})
+	assert.Empty(t, model)
+
+	model = adapter.ExtractModel([]byte(`{}`))
+	assert.Empty(t, model)
+}
+
+// =============================================================================
+// PROVIDER DETECTION
+// =============================================================================
+
+func TestGemini_ProviderDetection_XProviderHeader(t *testing.T) {
+	registry := adapters.NewRegistry()
+
+	headers := http.Header{}
+	headers.Set("X-Provider", "gemini")
+
+	provider, adapter := adapters.IdentifyAndGetAdapter(registry, "/some/path", headers)
+	assert.Equal(t, adapters.ProviderGemini, provider)
+	assert.NotNil(t, adapter)
+	assert.Equal(t, "gemini", adapter.Name())
+}
+
+func TestGemini_ProviderDetection_GoogleAPIKey(t *testing.T) {
+	registry := adapters.NewRegistry()
+
+	headers := http.Header{}
+	headers.Set("x-goog-api-key", "AIza-test-key")
+
+	provider, adapter := adapters.IdentifyAndGetAdapter(registry, "/some/path", headers)
+	assert.Equal(t, adapters.ProviderGemini, provider)
+	assert.NotNil(t, adapter)
+	assert.Equal(t, "gemini", adapter.Name())
+}
+
+func TestGemini_ProviderDetection_PathBased(t *testing.T) {
+	registry := adapters.NewRegistry()
+
+	headers := http.Header{}
+
+	provider, adapter := adapters.IdentifyAndGetAdapter(registry, "/v1beta/generativelanguage.googleapis.com/models/gemini-3-flash:generateContent", headers)
+	assert.Equal(t, adapters.ProviderGemini, provider)
+	assert.NotNil(t, adapter)
+	assert.Equal(t, "gemini", adapter.Name())
+}
+
+// =============================================================================
+// INTERFACE COMPLIANCE
+// =============================================================================
+
+func TestGemini_ImplementsAdapter(t *testing.T) {
+	var _ adapters.Adapter = adapters.NewGeminiAdapter()
+}
+
+// =============================================================================
+// PROVIDER FROM STRING
+// =============================================================================
+
+func TestGemini_ProviderFromString(t *testing.T) {
+	assert.Equal(t, adapters.ProviderGemini, adapters.ProviderFromString("gemini"))
+}

--- a/tests/gemini/unit/setup_test.go
+++ b/tests/gemini/unit/setup_test.go
@@ -1,0 +1,14 @@
+package unit
+
+import (
+	"os"
+	"testing"
+
+	"github.com/joho/godotenv"
+)
+
+func TestMain(m *testing.M) {
+	// Load .env from project root
+	godotenv.Load("../../../.env")
+	os.Exit(m.Run())
+}


### PR DESCRIPTION
Add GeminiAdapter implementing the full Adapter interface for Google Gemini's contents[]/parts[]/functionResponse format. Parses usageMetadata for token counts and handles models/ prefix stripping. Register in adapter registry, update provider identification test, and add 31 unit tests.