### PR TITLE
feat: hybrid skip_tools with provider-aware category mapping

### DIFF
--- a/internal/gateway/router.go
+++ b/internal/gateway/router.go
@@ -177,6 +177,7 @@ func (r *Router) toPipeContext(ctx *PipelineContext) *pipes.PipeContext {
 	pipeCtx.CompressionThreshold = ctx.CompressionThreshold
 	pipeCtx.CapturedBearerToken = ctx.CapturedBearerToken
 	pipeCtx.CapturedBetaHeader = ctx.CapturedBetaHeader
+	pipeCtx.Provider = ctx.Provider
 	return pipeCtx
 }
 

--- a/internal/pipes/config.go
+++ b/internal/pipes/config.go
@@ -129,6 +129,9 @@ type ToolOutputConfig struct {
 	// Expand context feature
 	EnableExpandContext bool `yaml:"enable_expand_context"` // Inject expand_context tool
 	IncludeExpandHint   bool `yaml:"include_expand_hint"`   // Add hint to compressed content
+
+	// Skip compression for specific tools (e.g., Read, Edit — needed for exact matching)
+	SkipTools []string `yaml:"skip_tools,omitempty"`
 }
 
 // Validate validates tool output pipe config.

--- a/internal/pipes/pipe.go
+++ b/internal/pipes/pipe.go
@@ -39,6 +39,9 @@ type PipeContext struct {
 	CapturedBearerToken string
 	CapturedBetaHeader  string // anthropic-beta header value from incoming request
 
+	// Provider of the incoming request (for provider-aware skip_tools)
+	Provider adapters.Provider
+
 	// Flags set by pipes
 	OutputCompressed bool
 	ToolsFiltered    bool

--- a/internal/pipes/tool_output/skip_tools.go
+++ b/internal/pipes/tool_output/skip_tools.go
@@ -1,0 +1,69 @@
+package tooloutput
+
+import (
+	"strings"
+
+	"github.com/compresr/context-gateway/internal/adapters"
+	"github.com/rs/zerolog/log"
+)
+
+// categoryMapping maps generic skip_tools categories to provider-specific tool names.
+// Users configure categories (lowercase): skip_tools: ["read", "edit"]
+// Only verified provider mappings are included. Other providers (OpenAI, Gemini, Ollama)
+// fall back to using all known tool names for the category.
+// TODO: Add verified mappings for OpenAI, Gemini, Ollama when tool names are confirmed.
+var categoryMapping = map[string]map[adapters.Provider][]string{
+	"read": {
+		adapters.ProviderAnthropic: {"Read"},
+		adapters.ProviderBedrock:   {"Read"},
+	},
+	"edit": {
+		adapters.ProviderAnthropic: {"Edit"},
+		adapters.ProviderBedrock:   {"Edit"},
+	},
+	"write": {
+		adapters.ProviderAnthropic: {"Write"},
+		adapters.ProviderBedrock:   {"Write"},
+	},
+	"bash": {
+		adapters.ProviderAnthropic: {"Bash"},
+		adapters.ProviderBedrock:   {"Bash"},
+	},
+	"glob": {
+		adapters.ProviderAnthropic: {"Glob"},
+		adapters.ProviderBedrock:   {"Glob"},
+	},
+	"grep": {
+		adapters.ProviderAnthropic: {"Grep"},
+		adapters.ProviderBedrock:   {"Grep"},
+	},
+}
+
+// BuildSkipSet resolves skip_tools categories to a set of provider-specific tool names.
+// Categories are case-insensitive. Unknown categories are treated as exact tool names
+// (backward compatible with skip_tools: ["Read", "Edit"]).
+func BuildSkipSet(categories []string, provider adapters.Provider) map[string]bool {
+	result := make(map[string]bool, len(categories)*2)
+	for _, cat := range categories {
+		lower := strings.ToLower(cat)
+		if providerMap, ok := categoryMapping[lower]; ok {
+			if toolNames, ok := providerMap[provider]; ok {
+				for _, name := range toolNames {
+					result[name] = true
+				}
+				continue
+			}
+			// Provider not in mapping — add all known tool names for this category
+			log.Debug().Str("category", cat).Str("provider", string(provider)).Msg("skip_tools: provider not in mapping, using all known tool names")
+			for _, toolNames := range providerMap {
+				for _, name := range toolNames {
+					result[name] = true
+				}
+			}
+		} else {
+			// Unknown category — use as exact tool name (backward compat)
+			result[cat] = true
+		}
+	}
+	return result
+}

--- a/tests/common/skip_tools_test.go
+++ b/tests/common/skip_tools_test.go
@@ -1,0 +1,69 @@
+package common
+
+import (
+	"testing"
+
+	"github.com/compresr/context-gateway/internal/adapters"
+	tooloutput "github.com/compresr/context-gateway/internal/pipes/tool_output"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBuildSkipSet_Anthropic(t *testing.T) {
+	set := tooloutput.BuildSkipSet([]string{"read", "edit"}, adapters.ProviderAnthropic)
+	assert.True(t, set["Read"])
+	assert.True(t, set["Edit"])
+	assert.False(t, set["Bash"])
+	assert.False(t, set["file_read"])
+}
+
+func TestBuildSkipSet_OpenAI_Fallback(t *testing.T) {
+	// OpenAI has no verified mapping — falls back to all known tool names for category
+	set := tooloutput.BuildSkipSet([]string{"read"}, adapters.ProviderOpenAI)
+	// Gets all known names (Anthropic + Bedrock both have "Read")
+	assert.True(t, set["Read"])
+	assert.Len(t, set, 1) // Only "Read" since Anthropic and Bedrock share the same name
+}
+
+func TestBuildSkipSet_CaseInsensitive(t *testing.T) {
+	set := tooloutput.BuildSkipSet([]string{"READ", "Edit", "bAsH"}, adapters.ProviderAnthropic)
+	assert.True(t, set["Read"])
+	assert.True(t, set["Edit"])
+	assert.True(t, set["Bash"])
+}
+
+func TestBuildSkipSet_ExactMatchFallback(t *testing.T) {
+	// Unknown category treated as exact tool name (backward compat)
+	set := tooloutput.BuildSkipSet([]string{"MyCustomTool"}, adapters.ProviderAnthropic)
+	assert.True(t, set["MyCustomTool"])
+	assert.Len(t, set, 1)
+}
+
+func TestBuildSkipSet_BackwardCompat(t *testing.T) {
+	// Old-style config: skip_tools: ["Read", "Edit"]
+	// "Read" lowercase = "read" category, matches; "Edit" lowercase = "edit" category, matches
+	set := tooloutput.BuildSkipSet([]string{"Read", "Edit"}, adapters.ProviderAnthropic)
+	assert.True(t, set["Read"])
+	assert.True(t, set["Edit"])
+}
+
+func TestBuildSkipSet_UnknownProvider(t *testing.T) {
+	// Unknown provider gets all tool names from all providers for the category
+	set := tooloutput.BuildSkipSet([]string{"read"}, adapters.ProviderUnknown)
+	assert.True(t, set["Read"])
+	assert.Len(t, set, 1) // Only "Read" — Anthropic and Bedrock share the same name
+}
+
+func TestBuildSkipSet_Empty(t *testing.T) {
+	set := tooloutput.BuildSkipSet(nil, adapters.ProviderAnthropic)
+	assert.Empty(t, set)
+
+	set = tooloutput.BuildSkipSet([]string{}, adapters.ProviderAnthropic)
+	assert.Empty(t, set)
+}
+
+func TestBuildSkipSet_MixedCategoriesAndExact(t *testing.T) {
+	set := tooloutput.BuildSkipSet([]string{"read", "MyTool"}, adapters.ProviderAnthropic)
+	assert.True(t, set["Read"])
+	assert.True(t, set["MyTool"])
+	assert.Len(t, set, 2)
+}


### PR DESCRIPTION
## Summary

Implements the hybrid approach discussed in #11: users configure generic categories (`skip_tools: ["read", "edit"]`), which are resolved to provider-specific tool names at request time.

- New `categoryMapping` in `skip_tools.go` maps categories to provider-specific tool names
- `BuildSkipSet()` resolves categories per-request based on detected provider
- Case-insensitive matching; unknown categories treated as exact tool names (e.g. `skip_tools: ["MyCustomTool"]`)
- Provider threaded through `PipeContext` for per-request resolution
- Skipped tools logged with `MappingStatus: "skipped_by_config"` in telemetry
- Only Anthropic and Bedrock mappings included for now (see [comment](https://github.com/Compresr-ai/Context-Gateway/pull/15#issuecomment-3898868587))

### Config format
```yaml
pipes:
  tool_output:
    skip_tools: ["read", "edit"]   # generic categories, case-insensitive
```

## Test plan

- [x] 8 unit tests covering: Anthropic, OpenAI fallback, case-insensitive, exact match, unknown provider, empty input, mixed categories
- [ ] CI lint + test

Closes #11
