### PR TITLE
feat: implement tool discovery pipe with relevance-based filtering

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -95,7 +95,7 @@ Client → Gateway:8080
 
 **Adapter** (`internal/adapters/adapter.go`): Provider-specific Extract/Apply pairs for each pipe type. Pipes never contain provider logic — they delegate to adapters. All provider detection goes through `IdentifyAndGetAdapter()` in `provider_identification.go`.
 
-**Pipe** (`internal/pipes/pipe.go`): `Process(*PipeContext) ([]byte, error)` — receives request body, returns modified body. Only tool_output is fully implemented.
+**Pipe** (`internal/pipes/pipe.go`): `Process(*PipeContext) ([]byte, error)` — receives request body, returns modified body. Both tool_output (compression) and tool_discovery (relevance filtering) are implemented.
 
 **Store** (`internal/store/store.go`): Dual-TTL shadow context storage. Original content: 5 min TTL (for expand_context). Compressed content: 24h TTL (for KV-cache reuse).
 
@@ -144,7 +144,7 @@ See `docs/slack-setup.md` for manual setup.
 
 ## Unimplemented (Stubs)
 
-- `internal/pipes/tool_discovery/tool_discovery.go` — Tool filtering pipe (returns original unchanged)
+(None — all adapters and pipes are implemented)
 
 ## Logging
 

--- a/internal/config/pipes.go
+++ b/internal/config/pipes.go
@@ -17,6 +17,7 @@ const (
 	StrategyPassthrough      = pipes.StrategyPassthrough
 	StrategyAPI              = pipes.StrategyAPI
 	StrategyExternalProvider = pipes.StrategyExternalProvider
+	StrategyRelevance        = pipes.StrategyRelevance
 )
 
 // CompressionThreshold type alias - re-exported from pipes package.

--- a/internal/pipes/tool_discovery/tool_discovery.go
+++ b/internal/pipes/tool_discovery/tool_discovery.go
@@ -6,28 +6,76 @@
 // FLOW:
 //  1. Receives adapter via PipeContext
 //  2. Calls adapter.ExtractToolDiscovery() to get tool definitions
-//  3. Filters tools based on relevance to query
-//  4. Calls adapter.ApplyToolDiscovery() to patch filtered tools back
+//  3. Scores tools using multi-signal relevance (recently used, keyword match, always-keep)
+//  4. Keeps top-scoring tools up to MaxTools or TargetRatio
+//  5. Calls adapter.ApplyToolDiscovery() to patch filtered tools back
 //
-// STATUS: Stub implementation - Process() is a no-op.
+// STRATEGY: "relevance" — local keyword-based filtering (no external API)
 package tooldiscovery
 
 import (
+	"strings"
+
+	"github.com/rs/zerolog/log"
+
+	"github.com/compresr/context-gateway/internal/adapters"
 	"github.com/compresr/context-gateway/internal/config"
 	"github.com/compresr/context-gateway/internal/pipes"
 )
 
+// Default configuration values.
+const (
+	DefaultMinTools = 5
+	DefaultMaxTools = 25
+)
+
+// Score weights for relevance signals.
+const (
+	scoreRecentlyUsed = 100 // Tool was used in conversation history
+	scoreAlwaysKeep   = 100 // Tool is in the always-keep list
+	scoreExactName    = 50  // Query contains exact tool name
+	scoreWordMatch    = 10  // Per-word overlap between query and tool name/description
+)
+
 // Pipe filters tools dynamically based on relevance to the current query.
 type Pipe struct {
-	enabled  bool
-	strategy string
+	enabled     bool
+	strategy    string
+	minTools    int
+	maxTools    int
+	targetRatio float64
+	alwaysKeep  map[string]bool
 }
 
 // New creates a new tool discovery pipe.
 func New(cfg *config.Config) *Pipe {
+	minTools := cfg.Pipes.ToolDiscovery.MinTools
+	if minTools == 0 {
+		minTools = DefaultMinTools
+	}
+
+	maxTools := cfg.Pipes.ToolDiscovery.MaxTools
+	if maxTools == 0 {
+		maxTools = DefaultMaxTools
+	}
+
+	targetRatio := cfg.Pipes.ToolDiscovery.TargetRatio
+	if targetRatio == 0 {
+		targetRatio = 0.8 // Keep 80% of tools by default
+	}
+
+	alwaysKeep := make(map[string]bool)
+	for _, name := range cfg.Pipes.ToolDiscovery.AlwaysKeep {
+		alwaysKeep[name] = true
+	}
+
 	return &Pipe{
-		enabled:  cfg.Pipes.ToolDiscovery.Enabled,
-		strategy: cfg.Pipes.ToolDiscovery.Strategy,
+		enabled:     cfg.Pipes.ToolDiscovery.Enabled,
+		strategy:    cfg.Pipes.ToolDiscovery.Strategy,
+		minTools:    minTools,
+		maxTools:    maxTools,
+		targetRatio: targetRatio,
+		alwaysKeep:  alwaysKeep,
 	}
 }
 
@@ -49,14 +97,221 @@ func (p *Pipe) Enabled() bool {
 // Process filters tools before sending to LLM.
 //
 // DESIGN: Pipes ALWAYS delegate extraction to adapters. Pipes contain NO
-// provider-specific logic - they only implement compression/filtering logic.
-//
-// STATUS: Not implemented in current release. Returns request unchanged.
+// provider-specific logic — they only implement filtering logic.
 func (p *Pipe) Process(ctx *pipes.PipeContext) ([]byte, error) {
 	if !p.enabled || p.strategy == config.StrategyPassthrough {
 		return ctx.OriginalRequest, nil
 	}
 
-	// Tool discovery/filtering not implemented in current release
-	return ctx.OriginalRequest, nil
+	if p.strategy != config.StrategyRelevance {
+		// Only relevance strategy is implemented locally
+		return ctx.OriginalRequest, nil
+	}
+
+	return p.filterByRelevance(ctx)
+}
+
+// filterByRelevance scores and filters tools based on multi-signal relevance.
+func (p *Pipe) filterByRelevance(ctx *pipes.PipeContext) ([]byte, error) {
+	if ctx.Adapter == nil || len(ctx.OriginalRequest) == 0 {
+		return ctx.OriginalRequest, nil
+	}
+
+	// Extract tool definitions via adapter
+	tools, err := ctx.Adapter.ExtractToolDiscovery(ctx.OriginalRequest, nil)
+	if err != nil {
+		log.Warn().Err(err).Msg("tool_discovery: extraction failed, skipping filtering")
+		return ctx.OriginalRequest, nil
+	}
+
+	totalTools := len(tools)
+	if totalTools == 0 {
+		return ctx.OriginalRequest, nil
+	}
+
+	// Skip filtering if below minimum threshold
+	if totalTools <= p.minTools {
+		log.Debug().
+			Int("tools", totalTools).
+			Int("min_tools", p.minTools).
+			Msg("tool_discovery: below min threshold, skipping")
+		return ctx.OriginalRequest, nil
+	}
+
+	// Get user query for keyword matching
+	query := ctx.Adapter.ExtractUserQuery(ctx.OriginalRequest)
+
+	// Get recently-used tool names from conversation history
+	recentTools := p.extractRecentlyUsedTools(ctx)
+
+	// Score each tool
+	type scoredTool struct {
+		tool  adapters.ExtractedContent
+		score int
+	}
+
+	scored := make([]scoredTool, 0, totalTools)
+	for _, tool := range tools {
+		score := p.scoreTool(tool, query, recentTools)
+		scored = append(scored, scoredTool{tool: tool, score: score})
+	}
+
+	// Determine how many tools to keep
+	keepCount := p.calculateKeepCount(totalTools)
+
+	// If we'd keep all tools anyway, skip filtering
+	if keepCount >= totalTools {
+		log.Debug().
+			Int("tools", totalTools).
+			Int("keep_count", keepCount).
+			Msg("tool_discovery: keep count >= total, skipping")
+		return ctx.OriginalRequest, nil
+	}
+
+	// Sort by score descending (simple insertion sort — tool counts are small)
+	for i := 1; i < len(scored); i++ {
+		for j := i; j > 0 && scored[j].score > scored[j-1].score; j-- {
+			scored[j], scored[j-1] = scored[j-1], scored[j]
+		}
+	}
+
+	// Build results with Keep flag
+	results := make([]adapters.CompressedResult, 0, totalTools)
+	kept := 0
+	for _, s := range scored {
+		keep := kept < keepCount || p.alwaysKeep[s.tool.ToolName]
+		results = append(results, adapters.CompressedResult{
+			ID:   s.tool.ID,
+			Keep: keep,
+		})
+		if keep {
+			kept++
+		}
+	}
+
+	// Apply filtered tools back via adapter
+	modified, err := ctx.Adapter.ApplyToolDiscovery(ctx.OriginalRequest, results)
+	if err != nil {
+		log.Warn().Err(err).Msg("tool_discovery: apply failed, returning original")
+		return ctx.OriginalRequest, nil
+	}
+
+	ctx.ToolsFiltered = true
+
+	log.Info().
+		Int("total", totalTools).
+		Int("kept", kept).
+		Int("removed", totalTools-kept).
+		Msg("tool_discovery: filtered tools by relevance")
+
+	return modified, nil
+}
+
+// calculateKeepCount returns how many tools to keep based on config.
+func (p *Pipe) calculateKeepCount(total int) int {
+	// Apply target ratio
+	byRatio := int(float64(total) * p.targetRatio)
+
+	// Cap at MaxTools
+	keep := byRatio
+	if keep > p.maxTools {
+		keep = p.maxTools
+	}
+
+	// Ensure we keep at least MinTools
+	if keep < p.minTools {
+		keep = p.minTools
+	}
+
+	return keep
+}
+
+// scoreTool computes a relevance score for a single tool.
+func (p *Pipe) scoreTool(tool adapters.ExtractedContent, query string, recentTools map[string]bool) int {
+	score := 0
+
+	// Signal 1: Always-keep list
+	if p.alwaysKeep[tool.ToolName] {
+		score += scoreAlwaysKeep
+	}
+
+	// Signal 2: Recently used in conversation
+	if recentTools[tool.ToolName] {
+		score += scoreRecentlyUsed
+	}
+
+	if query == "" {
+		return score
+	}
+
+	queryLower := strings.ToLower(query)
+	toolNameLower := strings.ToLower(tool.ToolName)
+
+	// Signal 3: Exact tool name appears in query
+	if strings.Contains(queryLower, toolNameLower) {
+		score += scoreExactName
+	}
+
+	// Signal 4: Word overlap between query and tool name + description
+	queryWords := tokenize(queryLower)
+	toolWords := tokenize(toolNameLower + " " + strings.ToLower(tool.Content))
+
+	toolWordSet := make(map[string]bool, len(toolWords))
+	for _, w := range toolWords {
+		toolWordSet[w] = true
+	}
+
+	for _, w := range queryWords {
+		if toolWordSet[w] {
+			score += scoreWordMatch
+		}
+	}
+
+	return score
+}
+
+// extractRecentlyUsedTools gets tool names from conversation history.
+// Uses ExtractToolOutput to find tool results, which contain tool names.
+func (p *Pipe) extractRecentlyUsedTools(ctx *pipes.PipeContext) map[string]bool {
+	recent := make(map[string]bool)
+
+	extracted, err := ctx.Adapter.ExtractToolOutput(ctx.OriginalRequest)
+	if err != nil || len(extracted) == 0 {
+		return recent
+	}
+
+	for _, ext := range extracted {
+		if ext.ToolName != "" {
+			recent[ext.ToolName] = true
+		}
+	}
+
+	return recent
+}
+
+// tokenize splits text into lowercase words, filtering short ones and stop words.
+func tokenize(text string) []string {
+	words := strings.FieldsFunc(text, func(r rune) bool {
+		return !((r >= 'a' && r <= 'z') || (r >= '0' && r <= '9'))
+	})
+
+	filtered := make([]string, 0, len(words))
+	for _, w := range words {
+		if len(w) >= 3 && !stopWords[w] {
+			filtered = append(filtered, w)
+		}
+	}
+	return filtered
+}
+
+// stopWords are common English words filtered during tokenization.
+var stopWords = map[string]bool{
+	"the": true, "and": true, "for": true, "are": true, "but": true,
+	"not": true, "you": true, "all": true, "can": true, "has": true,
+	"her": true, "was": true, "one": true, "our": true, "out": true,
+	"this": true, "that": true, "with": true, "have": true, "from": true,
+	"they": true, "been": true, "will": true, "each": true, "make": true,
+	"like": true, "just": true, "than": true, "them": true, "some": true,
+	"into": true, "when": true, "what": true, "which": true, "their": true,
+	"there": true, "about": true, "would": true, "these": true, "other": true,
 }

--- a/tests/anthropic/unit/adapter_test.go
+++ b/tests/anthropic/unit/adapter_test.go
@@ -89,7 +89,7 @@ func TestAnthropic_ExtractToolOutput_ArrayContent(t *testing.T) {
 // ANTHROPIC TOOL DISCOVERY TESTS (Stub - Not Yet Implemented)
 // =============================================================================
 
-func TestAnthropic_ExtractToolDiscovery_Stub(t *testing.T) {
+func TestAnthropic_ExtractToolDiscovery(t *testing.T) {
 	adapter := adapters.NewAnthropicAdapter()
 
 	body := []byte(`{
@@ -103,10 +103,13 @@ func TestAnthropic_ExtractToolDiscovery_Stub(t *testing.T) {
 	extracted, err := adapter.ExtractToolDiscovery(body, nil)
 
 	require.NoError(t, err)
-	assert.Empty(t, extracted) // Stub: Not yet implemented
+	require.Len(t, extracted, 1)
+	assert.Equal(t, "read_file", extracted[0].ID)
+	assert.Equal(t, "Read a file", extracted[0].Content)
+	assert.Equal(t, "tool_def", extracted[0].ContentType)
 }
 
-func TestAnthropic_ApplyToolDiscovery_Stub(t *testing.T) {
+func TestAnthropic_ApplyToolDiscovery(t *testing.T) {
 	adapter := adapters.NewAnthropicAdapter()
 
 	body := []byte(`{
@@ -124,7 +127,12 @@ func TestAnthropic_ApplyToolDiscovery_Stub(t *testing.T) {
 	modified, err := adapter.ApplyToolDiscovery(body, results)
 
 	require.NoError(t, err)
-	assert.Equal(t, body, modified) // Stub: returns unchanged
+
+	var req map[string]any
+	require.NoError(t, json.Unmarshal(modified, &req))
+	tools := req["tools"].([]any)
+	require.Len(t, tools, 1)
+	assert.Equal(t, "read_file", tools[0].(map[string]any)["name"])
 }
 
 // =============================================================================

--- a/tests/tool_discovery/unit/adapter_test.go
+++ b/tests/tool_discovery/unit/adapter_test.go
@@ -1,0 +1,423 @@
+package unit
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/compresr/context-gateway/internal/adapters"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// =============================================================================
+// OPENAI - EXTRACT TOOL DISCOVERY
+// =============================================================================
+
+func TestOpenAI_ExtractToolDiscovery(t *testing.T) {
+	adapter := adapters.NewOpenAIAdapter()
+
+	body := []byte(`{
+		"model": "gpt-4o",
+		"messages": [{"role": "user", "content": "hello"}],
+		"tools": [
+			{
+				"type": "function",
+				"function": {
+					"name": "read_file",
+					"description": "Read the contents of a file",
+					"parameters": {"type": "object", "properties": {"path": {"type": "string"}}}
+				}
+			},
+			{
+				"type": "function",
+				"function": {
+					"name": "write_file",
+					"description": "Write content to a file",
+					"parameters": {"type": "object", "properties": {"path": {"type": "string"}, "content": {"type": "string"}}}
+				}
+			}
+		]
+	}`)
+
+	extracted, err := adapter.ExtractToolDiscovery(body, nil)
+
+	require.NoError(t, err)
+	require.Len(t, extracted, 2)
+
+	assert.Equal(t, "read_file", extracted[0].ID)
+	assert.Equal(t, "Read the contents of a file", extracted[0].Content)
+	assert.Equal(t, "tool_def", extracted[0].ContentType)
+	assert.Equal(t, "read_file", extracted[0].ToolName)
+	assert.Equal(t, 0, extracted[0].MessageIndex)
+
+	assert.Equal(t, "write_file", extracted[1].ID)
+	assert.Equal(t, "Write content to a file", extracted[1].Content)
+	assert.Equal(t, 1, extracted[1].MessageIndex)
+}
+
+func TestOpenAI_ExtractToolDiscovery_NoTools(t *testing.T) {
+	adapter := adapters.NewOpenAIAdapter()
+
+	body := []byte(`{
+		"model": "gpt-4o",
+		"messages": [{"role": "user", "content": "hello"}]
+	}`)
+
+	extracted, err := adapter.ExtractToolDiscovery(body, nil)
+
+	require.NoError(t, err)
+	assert.Empty(t, extracted)
+}
+
+func TestOpenAI_ExtractToolDiscovery_EmptyTools(t *testing.T) {
+	adapter := adapters.NewOpenAIAdapter()
+
+	body := []byte(`{
+		"model": "gpt-4o",
+		"messages": [{"role": "user", "content": "hello"}],
+		"tools": []
+	}`)
+
+	extracted, err := adapter.ExtractToolDiscovery(body, nil)
+
+	require.NoError(t, err)
+	assert.Empty(t, extracted)
+}
+
+func TestOpenAI_ExtractToolDiscovery_NoDescription(t *testing.T) {
+	adapter := adapters.NewOpenAIAdapter()
+
+	body := []byte(`{
+		"model": "gpt-4o",
+		"tools": [
+			{
+				"type": "function",
+				"function": {
+					"name": "my_tool",
+					"parameters": {"type": "object"}
+				}
+			}
+		]
+	}`)
+
+	extracted, err := adapter.ExtractToolDiscovery(body, nil)
+
+	require.NoError(t, err)
+	require.Len(t, extracted, 1)
+	assert.Equal(t, "my_tool", extracted[0].ToolName)
+	assert.Equal(t, "", extracted[0].Content) // No description
+}
+
+// =============================================================================
+// OPENAI - APPLY TOOL DISCOVERY
+// =============================================================================
+
+func TestOpenAI_ApplyToolDiscovery(t *testing.T) {
+	adapter := adapters.NewOpenAIAdapter()
+
+	body := []byte(`{
+		"model": "gpt-4o",
+		"messages": [{"role": "user", "content": "hello"}],
+		"tools": [
+			{"type": "function", "function": {"name": "read_file", "description": "Read file"}},
+			{"type": "function", "function": {"name": "write_file", "description": "Write file"}},
+			{"type": "function", "function": {"name": "delete_file", "description": "Delete file"}}
+		]
+	}`)
+
+	results := []adapters.CompressedResult{
+		{ID: "read_file", Keep: true},
+		{ID: "write_file", Keep: false},
+		{ID: "delete_file", Keep: true},
+	}
+
+	modified, err := adapter.ApplyToolDiscovery(body, results)
+
+	require.NoError(t, err)
+
+	var req map[string]any
+	require.NoError(t, json.Unmarshal(modified, &req))
+
+	tools := req["tools"].([]any)
+	require.Len(t, tools, 2)
+
+	// Verify the right tools were kept
+	tool0 := tools[0].(map[string]any)["function"].(map[string]any)
+	tool1 := tools[1].(map[string]any)["function"].(map[string]any)
+	assert.Equal(t, "read_file", tool0["name"])
+	assert.Equal(t, "delete_file", tool1["name"])
+}
+
+func TestOpenAI_ApplyToolDiscovery_EmptyResults(t *testing.T) {
+	adapter := adapters.NewOpenAIAdapter()
+
+	body := []byte(`{
+		"model": "gpt-4o",
+		"tools": [
+			{"type": "function", "function": {"name": "read_file", "description": "Read file"}}
+		]
+	}`)
+
+	modified, err := adapter.ApplyToolDiscovery(body, nil)
+
+	require.NoError(t, err)
+	assert.Equal(t, body, modified) // Unchanged
+}
+
+func TestOpenAI_ApplyToolDiscovery_KeepAll(t *testing.T) {
+	adapter := adapters.NewOpenAIAdapter()
+
+	body := []byte(`{
+		"model": "gpt-4o",
+		"tools": [
+			{"type": "function", "function": {"name": "read_file", "description": "Read file"}},
+			{"type": "function", "function": {"name": "write_file", "description": "Write file"}}
+		]
+	}`)
+
+	results := []adapters.CompressedResult{
+		{ID: "read_file", Keep: true},
+		{ID: "write_file", Keep: true},
+	}
+
+	modified, err := adapter.ApplyToolDiscovery(body, results)
+
+	require.NoError(t, err)
+
+	var req map[string]any
+	require.NoError(t, json.Unmarshal(modified, &req))
+
+	tools := req["tools"].([]any)
+	assert.Len(t, tools, 2)
+}
+
+// =============================================================================
+// ANTHROPIC - EXTRACT TOOL DISCOVERY
+// =============================================================================
+
+func TestAnthropic_ExtractToolDiscovery(t *testing.T) {
+	adapter := adapters.NewAnthropicAdapter()
+
+	body := []byte(`{
+		"model": "claude-3-5-sonnet-20241022",
+		"messages": [{"role": "user", "content": "hello"}],
+		"tools": [
+			{
+				"name": "read_file",
+				"description": "Read the contents of a file from disk",
+				"input_schema": {"type": "object", "properties": {"path": {"type": "string"}}}
+			},
+			{
+				"name": "execute_command",
+				"description": "Execute a shell command",
+				"input_schema": {"type": "object", "properties": {"command": {"type": "string"}}}
+			}
+		]
+	}`)
+
+	extracted, err := adapter.ExtractToolDiscovery(body, nil)
+
+	require.NoError(t, err)
+	require.Len(t, extracted, 2)
+
+	assert.Equal(t, "read_file", extracted[0].ID)
+	assert.Equal(t, "Read the contents of a file from disk", extracted[0].Content)
+	assert.Equal(t, "tool_def", extracted[0].ContentType)
+	assert.Equal(t, "read_file", extracted[0].ToolName)
+	assert.Equal(t, 0, extracted[0].MessageIndex)
+
+	assert.Equal(t, "execute_command", extracted[1].ID)
+	assert.Equal(t, "Execute a shell command", extracted[1].Content)
+	assert.Equal(t, 1, extracted[1].MessageIndex)
+}
+
+func TestAnthropic_ExtractToolDiscovery_NoTools(t *testing.T) {
+	adapter := adapters.NewAnthropicAdapter()
+
+	body := []byte(`{
+		"model": "claude-3-5-sonnet-20241022",
+		"messages": [{"role": "user", "content": "hello"}]
+	}`)
+
+	extracted, err := adapter.ExtractToolDiscovery(body, nil)
+
+	require.NoError(t, err)
+	assert.Empty(t, extracted)
+}
+
+func TestAnthropic_ExtractToolDiscovery_NoDescription(t *testing.T) {
+	adapter := adapters.NewAnthropicAdapter()
+
+	body := []byte(`{
+		"model": "claude-3-5-sonnet-20241022",
+		"tools": [
+			{
+				"name": "custom_tool",
+				"input_schema": {"type": "object"}
+			}
+		]
+	}`)
+
+	extracted, err := adapter.ExtractToolDiscovery(body, nil)
+
+	require.NoError(t, err)
+	require.Len(t, extracted, 1)
+	assert.Equal(t, "custom_tool", extracted[0].ToolName)
+	assert.Equal(t, "", extracted[0].Content)
+}
+
+// =============================================================================
+// ANTHROPIC - APPLY TOOL DISCOVERY
+// =============================================================================
+
+func TestAnthropic_ApplyToolDiscovery(t *testing.T) {
+	adapter := adapters.NewAnthropicAdapter()
+
+	body := []byte(`{
+		"model": "claude-3-5-sonnet-20241022",
+		"messages": [{"role": "user", "content": "hello"}],
+		"tools": [
+			{"name": "read_file", "description": "Read file"},
+			{"name": "write_file", "description": "Write file"},
+			{"name": "search_code", "description": "Search code"}
+		]
+	}`)
+
+	results := []adapters.CompressedResult{
+		{ID: "read_file", Keep: true},
+		{ID: "write_file", Keep: false},
+		{ID: "search_code", Keep: true},
+	}
+
+	modified, err := adapter.ApplyToolDiscovery(body, results)
+
+	require.NoError(t, err)
+
+	var req map[string]any
+	require.NoError(t, json.Unmarshal(modified, &req))
+
+	tools := req["tools"].([]any)
+	require.Len(t, tools, 2)
+
+	tool0 := tools[0].(map[string]any)
+	tool1 := tools[1].(map[string]any)
+	assert.Equal(t, "read_file", tool0["name"])
+	assert.Equal(t, "search_code", tool1["name"])
+}
+
+func TestAnthropic_ApplyToolDiscovery_RemoveAll(t *testing.T) {
+	adapter := adapters.NewAnthropicAdapter()
+
+	body := []byte(`{
+		"model": "claude-3-5-sonnet-20241022",
+		"tools": [
+			{"name": "read_file", "description": "Read file"},
+			{"name": "write_file", "description": "Write file"}
+		]
+	}`)
+
+	results := []adapters.CompressedResult{
+		{ID: "read_file", Keep: false},
+		{ID: "write_file", Keep: false},
+	}
+
+	modified, err := adapter.ApplyToolDiscovery(body, results)
+
+	require.NoError(t, err)
+
+	var req map[string]any
+	require.NoError(t, json.Unmarshal(modified, &req))
+
+	tools := req["tools"].([]any)
+	assert.Len(t, tools, 0)
+}
+
+// =============================================================================
+// BEDROCK - DELEGATES TO ANTHROPIC
+// =============================================================================
+
+func TestBedrock_ExtractToolDiscovery(t *testing.T) {
+	adapter := adapters.NewBedrockAdapter()
+
+	body := []byte(`{
+		"anthropic_version": "bedrock-2023-05-31",
+		"messages": [{"role": "user", "content": "hello"}],
+		"tools": [
+			{"name": "read_file", "description": "Read a file"},
+			{"name": "list_dir", "description": "List directory contents"}
+		]
+	}`)
+
+	extracted, err := adapter.ExtractToolDiscovery(body, nil)
+
+	require.NoError(t, err)
+	require.Len(t, extracted, 2)
+	assert.Equal(t, "read_file", extracted[0].ToolName)
+	assert.Equal(t, "list_dir", extracted[1].ToolName)
+}
+
+func TestBedrock_ApplyToolDiscovery(t *testing.T) {
+	adapter := adapters.NewBedrockAdapter()
+
+	body := []byte(`{
+		"anthropic_version": "bedrock-2023-05-31",
+		"tools": [
+			{"name": "read_file", "description": "Read a file"},
+			{"name": "list_dir", "description": "List directory contents"}
+		]
+	}`)
+
+	results := []adapters.CompressedResult{
+		{ID: "read_file", Keep: true},
+		{ID: "list_dir", Keep: false},
+	}
+
+	modified, err := adapter.ApplyToolDiscovery(body, results)
+
+	require.NoError(t, err)
+
+	var req map[string]any
+	require.NoError(t, json.Unmarshal(modified, &req))
+
+	tools := req["tools"].([]any)
+	require.Len(t, tools, 1)
+	assert.Equal(t, "read_file", tools[0].(map[string]any)["name"])
+}
+
+// =============================================================================
+// INVALID JSON
+// =============================================================================
+
+func TestOpenAI_ExtractToolDiscovery_InvalidJSON(t *testing.T) {
+	adapter := adapters.NewOpenAIAdapter()
+
+	_, err := adapter.ExtractToolDiscovery([]byte(`not json`), nil)
+
+	assert.Error(t, err)
+}
+
+func TestAnthropic_ExtractToolDiscovery_InvalidJSON(t *testing.T) {
+	adapter := adapters.NewAnthropicAdapter()
+
+	_, err := adapter.ExtractToolDiscovery([]byte(`not json`), nil)
+
+	assert.Error(t, err)
+}
+
+func TestOpenAI_ApplyToolDiscovery_InvalidJSON(t *testing.T) {
+	adapter := adapters.NewOpenAIAdapter()
+
+	results := []adapters.CompressedResult{{ID: "test", Keep: true}}
+	_, err := adapter.ApplyToolDiscovery([]byte(`not json`), results)
+
+	assert.Error(t, err)
+}
+
+func TestAnthropic_ApplyToolDiscovery_InvalidJSON(t *testing.T) {
+	adapter := adapters.NewAnthropicAdapter()
+
+	results := []adapters.CompressedResult{{ID: "test", Keep: true}}
+	_, err := adapter.ApplyToolDiscovery([]byte(`not json`), results)
+
+	assert.Error(t, err)
+}

--- a/tests/tool_discovery/unit/pipe_test.go
+++ b/tests/tool_discovery/unit/pipe_test.go
@@ -1,0 +1,614 @@
+package unit
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/compresr/context-gateway/internal/adapters"
+	"github.com/compresr/context-gateway/internal/config"
+	"github.com/compresr/context-gateway/internal/pipes"
+	tooldiscovery "github.com/compresr/context-gateway/internal/pipes/tool_discovery"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// =============================================================================
+// PIPE METADATA
+// =============================================================================
+
+func TestPipe_Name(t *testing.T) {
+	pipe := tooldiscovery.New(testConfig("relevance", 5, 25, 0.8, nil))
+	assert.Equal(t, "tool_discovery", pipe.Name())
+}
+
+func TestPipe_Strategy(t *testing.T) {
+	tests := []struct {
+		name     string
+		strategy string
+	}{
+		{"passthrough", "passthrough"},
+		{"relevance", "relevance"},
+		{"api", "api"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			pipe := tooldiscovery.New(testConfig(tt.strategy, 5, 25, 0.8, nil))
+			assert.Equal(t, tt.strategy, pipe.Strategy())
+		})
+	}
+}
+
+func TestPipe_Enabled(t *testing.T) {
+	t.Run("enabled", func(t *testing.T) {
+		pipe := tooldiscovery.New(testConfig("relevance", 5, 25, 0.8, nil))
+		assert.True(t, pipe.Enabled())
+	})
+
+	t.Run("disabled", func(t *testing.T) {
+		cfg := testConfig("relevance", 5, 25, 0.8, nil)
+		cfg.Pipes.ToolDiscovery.Enabled = false
+		pipe := tooldiscovery.New(cfg)
+		assert.False(t, pipe.Enabled())
+	})
+}
+
+// =============================================================================
+// PASSTHROUGH AND DISABLED MODES
+// =============================================================================
+
+func TestPipe_Process_Disabled(t *testing.T) {
+	cfg := testConfig("relevance", 5, 25, 0.8, nil)
+	cfg.Pipes.ToolDiscovery.Enabled = false
+	pipe := tooldiscovery.New(cfg)
+
+	body := openAIRequestWithTools(10)
+	ctx := newOpenAIPipeContext(body)
+
+	result, err := pipe.Process(ctx)
+
+	require.NoError(t, err)
+	assert.Equal(t, body, result)
+	assert.False(t, ctx.ToolsFiltered)
+}
+
+func TestPipe_Process_Passthrough(t *testing.T) {
+	pipe := tooldiscovery.New(testConfig("passthrough", 5, 25, 0.8, nil))
+
+	body := openAIRequestWithTools(10)
+	ctx := newOpenAIPipeContext(body)
+
+	result, err := pipe.Process(ctx)
+
+	require.NoError(t, err)
+	assert.Equal(t, body, result)
+	assert.False(t, ctx.ToolsFiltered)
+}
+
+// =============================================================================
+// BELOW MIN THRESHOLD - NO FILTERING
+// =============================================================================
+
+func TestPipe_Process_BelowMinTools(t *testing.T) {
+	// MinTools=5, so 3 tools should not be filtered
+	pipe := tooldiscovery.New(testConfig("relevance", 5, 25, 0.8, nil))
+
+	body := openAIRequestWithTools(3)
+	ctx := newOpenAIPipeContext(body)
+
+	result, err := pipe.Process(ctx)
+
+	require.NoError(t, err)
+	assert.Equal(t, body, result)
+	assert.False(t, ctx.ToolsFiltered)
+}
+
+func TestPipe_Process_ExactlyMinTools(t *testing.T) {
+	// MinTools=5, so exactly 5 tools should not be filtered (<=)
+	pipe := tooldiscovery.New(testConfig("relevance", 5, 25, 0.8, nil))
+
+	body := openAIRequestWithTools(5)
+	ctx := newOpenAIPipeContext(body)
+
+	result, err := pipe.Process(ctx)
+
+	require.NoError(t, err)
+	assert.Equal(t, body, result)
+	assert.False(t, ctx.ToolsFiltered)
+}
+
+// =============================================================================
+// BASIC FILTERING
+// =============================================================================
+
+func TestPipe_Process_FiltersTools_OpenAI(t *testing.T) {
+	// MaxTools=3, MinTools=2, TargetRatio=0.5 → keep 50% of 10 = 5, capped at 3
+	pipe := tooldiscovery.New(testConfig("relevance", 2, 3, 0.5, nil))
+
+	body := openAIRequestWithToolsAndQuery(10, "read the file contents")
+	ctx := newOpenAIPipeContext(body)
+
+	result, err := pipe.Process(ctx)
+
+	require.NoError(t, err)
+	assert.True(t, ctx.ToolsFiltered)
+
+	var req map[string]any
+	require.NoError(t, json.Unmarshal(result, &req))
+
+	tools := req["tools"].([]any)
+	assert.LessOrEqual(t, len(tools), 3)
+	assert.Greater(t, len(tools), 0)
+}
+
+func TestPipe_Process_FiltersTools_Anthropic(t *testing.T) {
+	// MaxTools=3, MinTools=2, TargetRatio=0.5
+	pipe := tooldiscovery.New(testConfig("relevance", 2, 3, 0.5, nil))
+
+	body := anthropicRequestWithToolsAndQuery(10, "search for code patterns")
+	ctx := newAnthropicPipeContext(body)
+
+	result, err := pipe.Process(ctx)
+
+	require.NoError(t, err)
+	assert.True(t, ctx.ToolsFiltered)
+
+	var req map[string]any
+	require.NoError(t, json.Unmarshal(result, &req))
+
+	tools := req["tools"].([]any)
+	assert.LessOrEqual(t, len(tools), 3)
+	assert.Greater(t, len(tools), 0)
+}
+
+// =============================================================================
+// RELEVANCE SCORING - RECENTLY USED TOOLS
+// =============================================================================
+
+func TestPipe_Process_RecentlyUsedToolsScoreHigher(t *testing.T) {
+	// MaxTools=2, keep only 2 of 6 tools (int(6*0.4)=2)
+	pipe := tooldiscovery.New(testConfig("relevance", 1, 2, 0.4, nil))
+
+	// Request with tool results for "read_file" in conversation history
+	body := []byte(`{
+		"model": "gpt-4o",
+		"messages": [
+			{"role": "user", "content": "help me with code"},
+			{"role": "assistant", "content": null, "tool_calls": [
+				{"id": "call_1", "type": "function", "function": {"name": "read_file", "arguments": "{}"}}
+			]},
+			{"role": "tool", "tool_call_id": "call_1", "content": "file contents here"},
+			{"role": "user", "content": "now do something else"}
+		],
+		"tools": [
+			{"type": "function", "function": {"name": "read_file", "description": "Read a file"}},
+			{"type": "function", "function": {"name": "write_file", "description": "Write a file"}},
+			{"type": "function", "function": {"name": "delete_file", "description": "Delete a file"}},
+			{"type": "function", "function": {"name": "search_code", "description": "Search code"}},
+			{"type": "function", "function": {"name": "list_dir", "description": "List directory"}},
+			{"type": "function", "function": {"name": "run_tests", "description": "Run tests"}}
+		]
+	}`)
+
+	ctx := newOpenAIPipeContext(body)
+	result, err := pipe.Process(ctx)
+
+	require.NoError(t, err)
+	assert.True(t, ctx.ToolsFiltered)
+
+	var req map[string]any
+	require.NoError(t, json.Unmarshal(result, &req))
+
+	tools := req["tools"].([]any)
+	require.Len(t, tools, 2)
+
+	// read_file should be in the kept tools (it was recently used)
+	toolNames := extractToolNames(tools)
+	assert.Contains(t, toolNames, "read_file")
+}
+
+// =============================================================================
+// RELEVANCE SCORING - KEYWORD MATCHING
+// =============================================================================
+
+func TestPipe_Process_KeywordMatchScoring(t *testing.T) {
+	// MaxTools=2, keep only 2 of 6
+	pipe := tooldiscovery.New(testConfig("relevance", 1, 2, 0.3, nil))
+
+	body := []byte(`{
+		"model": "gpt-4o",
+		"messages": [
+			{"role": "user", "content": "search for code patterns in the file"}
+		],
+		"tools": [
+			{"type": "function", "function": {"name": "search_code", "description": "Search for code patterns"}},
+			{"type": "function", "function": {"name": "read_file", "description": "Read file contents"}},
+			{"type": "function", "function": {"name": "deploy_app", "description": "Deploy application to production"}},
+			{"type": "function", "function": {"name": "send_email", "description": "Send an email notification"}},
+			{"type": "function", "function": {"name": "create_db", "description": "Create database table"}},
+			{"type": "function", "function": {"name": "run_tests", "description": "Run test suite"}}
+		]
+	}`)
+
+	ctx := newOpenAIPipeContext(body)
+	result, err := pipe.Process(ctx)
+
+	require.NoError(t, err)
+	assert.True(t, ctx.ToolsFiltered)
+
+	var req map[string]any
+	require.NoError(t, json.Unmarshal(result, &req))
+
+	tools := req["tools"].([]any)
+	toolNames := extractToolNames(tools)
+
+	// search_code and read_file should score higher due to keyword overlap
+	assert.Contains(t, toolNames, "search_code")
+}
+
+// =============================================================================
+// ALWAYS KEEP LIST
+// =============================================================================
+
+func TestPipe_Process_AlwaysKeepList(t *testing.T) {
+	// MaxTools=2, but always_keep includes "run_tests"
+	alwaysKeep := []string{"run_tests"}
+	pipe := tooldiscovery.New(testConfig("relevance", 1, 2, 0.3, alwaysKeep))
+
+	body := []byte(`{
+		"model": "gpt-4o",
+		"messages": [
+			{"role": "user", "content": "search for code patterns"}
+		],
+		"tools": [
+			{"type": "function", "function": {"name": "search_code", "description": "Search for code patterns"}},
+			{"type": "function", "function": {"name": "read_file", "description": "Read file contents"}},
+			{"type": "function", "function": {"name": "deploy_app", "description": "Deploy application"}},
+			{"type": "function", "function": {"name": "send_email", "description": "Send email"}},
+			{"type": "function", "function": {"name": "create_db", "description": "Create database"}},
+			{"type": "function", "function": {"name": "run_tests", "description": "Run tests"}}
+		]
+	}`)
+
+	ctx := newOpenAIPipeContext(body)
+	result, err := pipe.Process(ctx)
+
+	require.NoError(t, err)
+	assert.True(t, ctx.ToolsFiltered)
+
+	var req map[string]any
+	require.NoError(t, json.Unmarshal(result, &req))
+
+	tools := req["tools"].([]any)
+	toolNames := extractToolNames(tools)
+
+	// run_tests should be kept because it's in always_keep
+	assert.Contains(t, toolNames, "run_tests")
+}
+
+// =============================================================================
+// KEEP COUNT CALCULATION
+// =============================================================================
+
+func TestPipe_Process_TargetRatioDeterminesCount(t *testing.T) {
+	// 10 tools, target_ratio=0.6 → keep 6, capped at MaxTools=8
+	pipe := tooldiscovery.New(testConfig("relevance", 2, 8, 0.6, nil))
+
+	body := openAIRequestWithToolsAndQuery(10, "test query")
+	ctx := newOpenAIPipeContext(body)
+
+	result, err := pipe.Process(ctx)
+
+	require.NoError(t, err)
+	assert.True(t, ctx.ToolsFiltered)
+
+	var req map[string]any
+	require.NoError(t, json.Unmarshal(result, &req))
+
+	tools := req["tools"].([]any)
+	assert.Equal(t, 6, len(tools))
+}
+
+func TestPipe_Process_MaxToolsCapsCount(t *testing.T) {
+	// 20 tools, target_ratio=0.8 → keep 16, but MaxTools=5 caps it
+	pipe := tooldiscovery.New(testConfig("relevance", 2, 5, 0.8, nil))
+
+	body := openAIRequestWithToolsAndQuery(20, "test query")
+	ctx := newOpenAIPipeContext(body)
+
+	result, err := pipe.Process(ctx)
+
+	require.NoError(t, err)
+	assert.True(t, ctx.ToolsFiltered)
+
+	var req map[string]any
+	require.NoError(t, json.Unmarshal(result, &req))
+
+	tools := req["tools"].([]any)
+	assert.Equal(t, 5, len(tools))
+}
+
+func TestPipe_Process_MinToolsFloor(t *testing.T) {
+	// 10 tools, target_ratio=0.1 → keep 1, but MinTools=3 floors it
+	pipe := tooldiscovery.New(testConfig("relevance", 3, 25, 0.1, nil))
+
+	body := openAIRequestWithToolsAndQuery(10, "test query")
+	ctx := newOpenAIPipeContext(body)
+
+	result, err := pipe.Process(ctx)
+
+	require.NoError(t, err)
+	assert.True(t, ctx.ToolsFiltered)
+
+	var req map[string]any
+	require.NoError(t, json.Unmarshal(result, &req))
+
+	tools := req["tools"].([]any)
+	assert.Equal(t, 3, len(tools))
+}
+
+// =============================================================================
+// EDGE CASES
+// =============================================================================
+
+func TestPipe_Process_NoAdapter(t *testing.T) {
+	pipe := tooldiscovery.New(testConfig("relevance", 2, 5, 0.5, nil))
+
+	body := openAIRequestWithTools(10)
+	ctx := &pipes.PipeContext{
+		Adapter:         nil,
+		OriginalRequest: body,
+	}
+
+	result, err := pipe.Process(ctx)
+
+	require.NoError(t, err)
+	assert.Equal(t, body, result)
+}
+
+func TestPipe_Process_EmptyBody(t *testing.T) {
+	pipe := tooldiscovery.New(testConfig("relevance", 2, 5, 0.5, nil))
+
+	ctx := newOpenAIPipeContext(nil)
+
+	result, err := pipe.Process(ctx)
+
+	require.NoError(t, err)
+	assert.Nil(t, result)
+}
+
+func TestPipe_Process_NoQuery(t *testing.T) {
+	// When no user query exists, should still work (using only recently-used and always-keep signals)
+	pipe := tooldiscovery.New(testConfig("relevance", 1, 3, 0.3, nil))
+
+	body := []byte(`{
+		"model": "gpt-4o",
+		"tools": [
+			{"type": "function", "function": {"name": "tool_1", "description": "First tool"}},
+			{"type": "function", "function": {"name": "tool_2", "description": "Second tool"}},
+			{"type": "function", "function": {"name": "tool_3", "description": "Third tool"}},
+			{"type": "function", "function": {"name": "tool_4", "description": "Fourth tool"}},
+			{"type": "function", "function": {"name": "tool_5", "description": "Fifth tool"}},
+			{"type": "function", "function": {"name": "tool_6", "description": "Sixth tool"}}
+		]
+	}`)
+
+	ctx := newOpenAIPipeContext(body)
+	result, err := pipe.Process(ctx)
+
+	require.NoError(t, err)
+	// Should still filter (tools > minTools) even without a query
+	assert.True(t, ctx.ToolsFiltered)
+
+	var req map[string]any
+	require.NoError(t, json.Unmarshal(result, &req))
+	tools := req["tools"].([]any)
+	assert.LessOrEqual(t, len(tools), 3)
+}
+
+func TestPipe_Process_KeepCountExceedsTotalSkips(t *testing.T) {
+	// target_ratio=1.0 would keep all tools, so no filtering should happen
+	pipe := tooldiscovery.New(testConfig("relevance", 2, 100, 1.0, nil))
+
+	body := openAIRequestWithToolsAndQuery(10, "test query")
+	ctx := newOpenAIPipeContext(body)
+
+	result, err := pipe.Process(ctx)
+
+	require.NoError(t, err)
+	assert.False(t, ctx.ToolsFiltered)
+	assert.Equal(t, body, result)
+}
+
+// =============================================================================
+// CONFIG VALIDATION
+// =============================================================================
+
+func TestToolDiscoveryConfig_Validate_Disabled(t *testing.T) {
+	cfg := &config.Config{}
+	cfg.Pipes.ToolDiscovery.Enabled = false
+	err := cfg.Pipes.ToolDiscovery.Validate()
+	assert.NoError(t, err)
+}
+
+func TestToolDiscoveryConfig_Validate_Passthrough(t *testing.T) {
+	cfg := &config.Config{}
+	cfg.Pipes.ToolDiscovery.Enabled = true
+	cfg.Pipes.ToolDiscovery.Strategy = "passthrough"
+	err := cfg.Pipes.ToolDiscovery.Validate()
+	assert.NoError(t, err)
+}
+
+func TestToolDiscoveryConfig_Validate_Relevance(t *testing.T) {
+	cfg := &config.Config{}
+	cfg.Pipes.ToolDiscovery.Enabled = true
+	cfg.Pipes.ToolDiscovery.Strategy = "relevance"
+	err := cfg.Pipes.ToolDiscovery.Validate()
+	assert.NoError(t, err)
+}
+
+func TestToolDiscoveryConfig_Validate_APIMissingEndpoint(t *testing.T) {
+	cfg := &config.Config{}
+	cfg.Pipes.ToolDiscovery.Enabled = true
+	cfg.Pipes.ToolDiscovery.Strategy = "api"
+	err := cfg.Pipes.ToolDiscovery.Validate()
+	assert.Error(t, err)
+}
+
+func TestToolDiscoveryConfig_Validate_APIWithProvider(t *testing.T) {
+	cfg := &config.Config{}
+	cfg.Pipes.ToolDiscovery.Enabled = true
+	cfg.Pipes.ToolDiscovery.Strategy = "api"
+	cfg.Pipes.ToolDiscovery.Provider = "some_provider"
+	err := cfg.Pipes.ToolDiscovery.Validate()
+	assert.NoError(t, err)
+}
+
+func TestToolDiscoveryConfig_Validate_UnknownStrategy(t *testing.T) {
+	cfg := &config.Config{}
+	cfg.Pipes.ToolDiscovery.Enabled = true
+	cfg.Pipes.ToolDiscovery.Strategy = "unknown_strategy"
+	err := cfg.Pipes.ToolDiscovery.Validate()
+	assert.Error(t, err)
+}
+
+// =============================================================================
+// HELPERS
+// =============================================================================
+
+func testConfig(strategy string, minTools, maxTools int, targetRatio float64, alwaysKeep []string) *config.Config {
+	return &config.Config{
+		Pipes: config.PipesConfig{
+			ToolDiscovery: config.ToolDiscoveryPipeConfig{
+				Enabled:     true,
+				Strategy:    strategy,
+				MinTools:    minTools,
+				MaxTools:    maxTools,
+				TargetRatio: targetRatio,
+				AlwaysKeep:  alwaysKeep,
+			},
+		},
+	}
+}
+
+func newOpenAIPipeContext(body []byte) *pipes.PipeContext {
+	registry := adapters.NewRegistry()
+	adapter := registry.Get("openai")
+	return pipes.NewPipeContext(adapter, body)
+}
+
+func newAnthropicPipeContext(body []byte) *pipes.PipeContext {
+	registry := adapters.NewRegistry()
+	adapter := registry.Get("anthropic")
+	return pipes.NewPipeContext(adapter, body)
+}
+
+func openAIRequestWithTools(n int) []byte {
+	return openAIRequestWithToolsAndQuery(n, "")
+}
+
+func openAIRequestWithToolsAndQuery(n int, query string) []byte {
+	tools := make([]map[string]any, n)
+	for i := 0; i < n; i++ {
+		tools[i] = map[string]any{
+			"type": "function",
+			"function": map[string]any{
+				"name":        toolName(i),
+				"description": toolDescription(i),
+			},
+		}
+	}
+
+	req := map[string]any{
+		"model": "gpt-4o",
+		"tools": tools,
+	}
+
+	if query != "" {
+		req["messages"] = []map[string]any{
+			{"role": "user", "content": query},
+		}
+	}
+
+	body, _ := json.Marshal(req)
+	return body
+}
+
+func anthropicRequestWithToolsAndQuery(n int, query string) []byte {
+	tools := make([]map[string]any, n)
+	for i := 0; i < n; i++ {
+		tools[i] = map[string]any{
+			"name":         toolName(i),
+			"description":  toolDescription(i),
+			"input_schema": map[string]any{"type": "object"},
+		}
+	}
+
+	req := map[string]any{
+		"model": "claude-3-5-sonnet-20241022",
+		"tools": tools,
+	}
+
+	if query != "" {
+		req["messages"] = []map[string]any{
+			{"role": "user", "content": query},
+		}
+	}
+
+	body, _ := json.Marshal(req)
+	return body
+}
+
+func toolName(i int) string {
+	names := []string{
+		"read_file", "write_file", "search_code", "list_dir", "execute_command",
+		"create_file", "delete_file", "git_commit", "run_tests", "deploy_app",
+		"send_email", "fetch_url", "parse_json", "compress_data", "encrypt_data",
+		"decrypt_data", "validate_schema", "generate_report", "upload_file", "download_file",
+	}
+	return names[i%len(names)]
+}
+
+func toolDescription(i int) string {
+	descriptions := []string{
+		"Read the contents of a file from disk",
+		"Write content to a file on disk",
+		"Search for code patterns across files",
+		"List contents of a directory",
+		"Execute a shell command",
+		"Create a new file with content",
+		"Delete a file from disk",
+		"Create a git commit with message",
+		"Run the test suite",
+		"Deploy the application to production",
+		"Send an email notification",
+		"Fetch content from a URL",
+		"Parse a JSON string into structured data",
+		"Compress data using gzip",
+		"Encrypt data with AES-256",
+		"Decrypt AES-256 encrypted data",
+		"Validate data against a JSON schema",
+		"Generate a formatted report",
+		"Upload a file to cloud storage",
+		"Download a file from cloud storage",
+	}
+	return descriptions[i%len(descriptions)]
+}
+
+func extractToolNames(tools []any) []string {
+	names := make([]string, 0, len(tools))
+	for _, t := range tools {
+		tool := t.(map[string]any)
+		// Try OpenAI format
+		if fn, ok := tool["function"].(map[string]any); ok {
+			if name, ok := fn["name"].(string); ok {
+				names = append(names, name)
+			}
+		}
+		// Try Anthropic format
+		if name, ok := tool["name"].(string); ok {
+			names = append(names, name)
+		}
+	}
+	return names
+}

--- a/tests/tool_discovery/unit/setup_test.go
+++ b/tests/tool_discovery/unit/setup_test.go
@@ -1,0 +1,18 @@
+package unit
+
+import (
+	"io"
+	"os"
+	"testing"
+
+	"github.com/joho/godotenv"
+	"github.com/rs/zerolog"
+	"github.com/rs/zerolog/log"
+)
+
+func TestMain(m *testing.M) {
+	godotenv.Load("../../../.env")
+	zerolog.SetGlobalLevel(zerolog.Disabled)
+	log.Logger = zerolog.New(io.Discard)
+	os.Exit(m.Run())
+}


### PR DESCRIPTION
Add local relevance scoring to filter tool definitions before sending to LLM, reducing token overhead when many tools are registered.

Multi-signal scoring: recently-used tools, keyword overlap, always-keep list. Configurable via max_tools, min_tools, target_ratio, always_keep.

Implements ExtractToolDiscovery/ApplyToolDiscovery for OpenAI and Anthropic adapters. Bedrock/Ollama delegate to their parent adapters.