### PR TITLE
fix-codex-startup-proxy Make Codex startup compatible with proxy

### DIFF
--- a/internal/gateway/gateway.go
+++ b/internal/gateway/gateway.go
@@ -633,7 +633,7 @@ func (g *Gateway) setupRoutes(mux *http.ServeMux) {
 	mux.HandleFunc("/api/prompts/erase", g.handleErasePrompts)
 	mux.HandleFunc("/api/compress/", g.handleCompressAPINotFound)
 	mux.HandleFunc("/stats", g.handleStats)
-	mux.HandleFunc("/v1/models", g.handleModels)
+	g.registerModelRoutes(mux)
 
 	// Session monitoring dashboard
 	monitorHandlers := dashboard.NewHandlers(g.monitorStore, g.monitorHub)

--- a/internal/gateway/handler.go
+++ b/internal/gateway/handler.go
@@ -348,6 +348,11 @@ func (g *Gateway) handleProxy(w http.ResponseWriter, r *http.Request) {
 	startTime := time.Now()
 	requestID := g.getRequestID(r)
 
+	if isWebSocketUpgrade(r) {
+		g.handleWebSocketProxy(w, r)
+		return
+	}
+
 	// Validate request
 	if r.Method != http.MethodPost {
 		g.alerts.FlagInvalidRequest(requestID, "method not allowed", nil)
@@ -811,17 +816,9 @@ func (g *Gateway) processCompressionPipeline(body []byte, pipeCtx *PipelineConte
 // forwardPassthrough forwards the request body unchanged to upstream.
 func (g *Gateway) forwardPassthrough(ctx context.Context, r *http.Request, body []byte) (*http.Response, forwardAuthMeta, error) {
 	authMeta := forwardAuthMeta{InitialMode: "unknown", EffectiveMode: "unknown"}
-	targetURL := r.Header.Get(HeaderTargetURL)
-	if targetURL != "" {
-		// X-Target-URL provided - append request path if not already included
-		if !strings.HasSuffix(targetURL, r.URL.Path) {
-			targetURL = strings.TrimSuffix(targetURL, "/") + r.URL.Path
-		}
-	} else {
-		targetURL = g.autoDetectTargetURL(r)
-		if targetURL == "" {
-			return nil, authMeta, fmt.Errorf("missing %s header", HeaderTargetURL)
-		}
+	targetURL, err := g.resolveTargetURL(r)
+	if err != nil {
+		return nil, authMeta, err
 	}
 
 	// Detect if this is a Bedrock request
@@ -868,7 +865,7 @@ func (g *Gateway) forwardPassthrough(ctx context.Context, r *http.Request, body 
 
 	sendUpstream := func(useAPIKeyMode bool, fallbackHeaders map[string]string) (*http.Response, []byte, error) {
 		// #nosec G704 -- targetURL is from configured provider URLs, not user input
-		httpReq, reqErr := http.NewRequestWithContext(ctx, "POST", targetURL, bytes.NewReader(body))
+		httpReq, reqErr := http.NewRequestWithContext(ctx, r.Method, targetURL, bytes.NewReader(body))
 		if reqErr != nil {
 			return nil, nil, reqErr
 		}
@@ -965,6 +962,22 @@ func (g *Gateway) forwardPassthrough(ctx context.Context, r *http.Request, body 
 	}
 
 	return resp, authMeta, nil
+}
+
+func (g *Gateway) resolveTargetURL(r *http.Request) (string, error) {
+	targetURL := r.Header.Get(HeaderTargetURL)
+	if targetURL != "" {
+		// X-Target-URL provided - append request path if not already included
+		if !strings.HasSuffix(targetURL, r.URL.Path) {
+			targetURL = strings.TrimSuffix(targetURL, "/") + r.URL.Path
+		}
+	} else {
+		targetURL = g.autoDetectTargetURL(r)
+		if targetURL == "" {
+			return "", fmt.Errorf("missing %s header", HeaderTargetURL)
+		}
+	}
+	return targetURL, nil
 }
 
 // isBedrockRequest checks if the request path matches Bedrock URL patterns.

--- a/internal/gateway/handler_test.go
+++ b/internal/gateway/handler_test.go
@@ -1,11 +1,17 @@
 package gateway
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
+	"github.com/coder/websocket"
+	"github.com/compresr/context-gateway/internal/adapters"
+	"github.com/compresr/context-gateway/internal/auth"
+	"github.com/compresr/context-gateway/internal/config"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -16,8 +22,8 @@ import (
 
 func TestSanitizeModelName(t *testing.T) {
 	tests := []struct {
-		name     string
-		input    string
+		name      string
+		input     string
 		wantModel string
 	}{
 		{
@@ -160,4 +166,135 @@ func TestWriteError_InternalServerError(t *testing.T) {
 	errObj, ok := body["error"].(map[string]interface{})
 	require.True(t, ok)
 	assert.Equal(t, "internal error", errObj["message"])
+}
+
+func TestSetupRoutes_RegistersModelsAlias(t *testing.T) {
+	g := &Gateway{}
+	mux := http.NewServeMux()
+
+	g.registerModelRoutes(mux)
+
+	req := httptest.NewRequest(http.MethodGet, "/models?client_version=0.114.0", nil)
+	rec := httptest.NewRecorder()
+
+	mux.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	var body codexModelsResponse
+	err := json.Unmarshal(rec.Body.Bytes(), &body)
+	require.NoError(t, err)
+	assert.NotEmpty(t, body.Models)
+}
+
+func TestHandleModels_V1ReturnsOpenAICompatibleList(t *testing.T) {
+	g := &Gateway{}
+
+	req := httptest.NewRequest(http.MethodGet, "/v1/models", nil)
+	rec := httptest.NewRecorder()
+
+	g.handleModels(rec, req)
+
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	var body modelsResponse
+	err := json.Unmarshal(rec.Body.Bytes(), &body)
+	require.NoError(t, err)
+	assert.Equal(t, "list", body.Object)
+	assert.NotEmpty(t, body.Data)
+}
+
+func TestHandleModels_ProxiesUpstreamWhenAuthContextPresent(t *testing.T) {
+	EnableLocalHostsForTesting()
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		assert.Equal(t, "/models", r.URL.Path)
+		assert.Equal(t, "Bearer subscription-token", r.Header.Get("Authorization"))
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"models":[{"slug":"gpt-5.4"}]}`))
+	}))
+	defer upstream.Close()
+
+	g := &Gateway{
+		registry:     adapters.NewRegistry(),
+		authRegistry: auth.NewRegistry(),
+		httpClient:   upstream.Client(),
+		configReloader: config.NewReloader(&config.Config{
+			Server:  config.ServerConfig{Port: 18081},
+			Bedrock: config.BedrockConfig{Enabled: false},
+		}, ""),
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/models?client_version=0.114.0", nil)
+	req.Header.Set("Authorization", "Bearer subscription-token")
+	req.Header.Set(HeaderTargetURL, upstream.URL)
+	rec := httptest.NewRecorder()
+
+	g.handleModels(rec, req)
+
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.JSONEq(t, `{"models":[{"slug":"gpt-5.4"}]}`, rec.Body.String())
+}
+
+func TestHandleModels_ChatGPTSubscriptionUsesSyntheticList(t *testing.T) {
+	g := &Gateway{}
+
+	req := httptest.NewRequest(http.MethodGet, "/models?client_version=0.114.0", nil)
+	req.Header.Set("Authorization", "Bearer subscription-token")
+	rec := httptest.NewRecorder()
+
+	g.handleModels(rec, req)
+
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	var body codexModelsResponse
+	err := json.Unmarshal(rec.Body.Bytes(), &body)
+	require.NoError(t, err)
+	assert.NotEmpty(t, body.Models)
+}
+
+func TestHandleProxy_WebSocketUpgradeProxiesResponses(t *testing.T) {
+	EnableLocalHostsForTesting()
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/responses", r.URL.Path)
+		assert.Equal(t, "Bearer subscription-token", r.Header.Get("Authorization"))
+
+		conn, err := websocket.Accept(w, r, &websocket.AcceptOptions{InsecureSkipVerify: true})
+		require.NoError(t, err)
+		defer func() { _ = conn.CloseNow() }()
+
+		ctx := context.Background()
+		msgType, payload, err := conn.Read(ctx)
+		require.NoError(t, err)
+		assert.Equal(t, websocket.MessageText, msgType)
+		assert.Equal(t, "ping", string(payload))
+		require.NoError(t, conn.Write(ctx, msgType, []byte("pong")))
+	}))
+	defer upstream.Close()
+
+	g := &Gateway{}
+	gatewayServer := httptest.NewServer(http.HandlerFunc(g.handleProxy))
+	defer gatewayServer.Close()
+
+	headers := http.Header{}
+	headers.Set("Authorization", "Bearer subscription-token")
+	headers.Set(HeaderTargetURL, upstream.URL)
+
+	ctx := context.Background()
+	conn, resp, err := websocket.Dial(ctx, "ws"+strings.TrimPrefix(gatewayServer.URL, "http")+"/responses", &websocket.DialOptions{
+		HTTPHeader: headers,
+	})
+	if resp != nil && resp.Body != nil {
+		_ = resp.Body.Close()
+	}
+	require.NoError(t, err)
+	defer func() { _ = conn.CloseNow() }()
+
+	require.NoError(t, conn.Write(ctx, websocket.MessageText, []byte("ping")))
+	msgType, payload, err := conn.Read(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, websocket.MessageText, msgType)
+	assert.Equal(t, "pong", string(payload))
 }

--- a/internal/gateway/handler_websocket.go
+++ b/internal/gateway/handler_websocket.go
@@ -1,0 +1,190 @@
+package gateway
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"github.com/coder/websocket"
+	"github.com/rs/zerolog/log"
+)
+
+var websocketForwardHeaders = []string{
+	"Authorization",
+	"x-api-key",
+	"x-goog-api-key",
+	"api-key",
+	"anthropic-version",
+	"anthropic-beta",
+	"Chatgpt-Account-Id",
+	"Originator",
+	"Session_id",
+	"Version",
+	"X-Codex-Turn-Metadata",
+	"Origin",
+	"User-Agent",
+	"Accept-Language",
+}
+
+func isWebSocketUpgrade(r *http.Request) bool {
+	return strings.EqualFold(r.Header.Get("Upgrade"), "websocket") &&
+		strings.Contains(strings.ToLower(r.Header.Get("Connection")), "upgrade")
+}
+
+func (g *Gateway) handleWebSocketProxy(w http.ResponseWriter, r *http.Request) {
+	targetURL, err := g.resolveTargetURL(r)
+	if err != nil {
+		g.writeError(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	wsURL, err := buildWebSocketTargetURL(targetURL, r)
+	if err != nil {
+		g.writeError(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	parsedURL, err := url.Parse(wsURL)
+	if err != nil {
+		g.writeError(w, "invalid websocket target URL", http.StatusBadRequest)
+		return
+	}
+	if !g.isAllowedHost(parsedURL.Host) {
+		g.writeError(w, fmt.Sprintf("target host not allowed: %s", parsedURL.Host), http.StatusBadRequest)
+		return
+	}
+
+	dialHeaders := make(http.Header)
+	for _, headerName := range websocketForwardHeaders {
+		for _, value := range r.Header.Values(headerName) {
+			dialHeaders.Add(headerName, value)
+		}
+	}
+
+	subprotocols := splitHeaderTokens(r.Header.Values("Sec-WebSocket-Protocol"))
+
+	dialOptions := &websocket.DialOptions{
+		HTTPHeader:   dialHeaders,
+		Subprotocols: subprotocols,
+	}
+	if g.httpClient != nil {
+		dialOptions.HTTPClient = g.httpClient
+	}
+
+	upstreamConn, resp, err := websocket.Dial(r.Context(), wsURL, dialOptions)
+	if resp != nil && resp.Body != nil {
+		_ = resp.Body.Close()
+	}
+	if err != nil {
+		statusCode := http.StatusBadGateway
+		if resp != nil && resp.StatusCode > 0 {
+			statusCode = resp.StatusCode
+		}
+		log.Error().Err(err).Str("target_url", wsURL).Int("status", statusCode).Msg("websocket upstream dial failed")
+		g.writeError(w, "upstream websocket connection failed", statusCode)
+		return
+	}
+	defer func() { _ = upstreamConn.CloseNow() }()
+
+	acceptOptions := &websocket.AcceptOptions{InsecureSkipVerify: true}
+	if upstreamSubprotocol := upstreamConn.Subprotocol(); upstreamSubprotocol != "" {
+		acceptOptions.Subprotocols = []string{upstreamSubprotocol}
+	}
+
+	clientConn, err := websocket.Accept(w, r, acceptOptions)
+	if err != nil {
+		log.Error().Err(err).Msg("websocket client accept failed")
+		return
+	}
+	defer func() { _ = clientConn.CloseNow() }()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	errCh := make(chan error, 2)
+	go func() {
+		errCh <- relayWebSocketMessages(ctx, upstreamConn, clientConn)
+	}()
+	go func() {
+		errCh <- relayWebSocketMessages(ctx, clientConn, upstreamConn)
+	}()
+
+	firstErr := <-errCh
+	if firstErr != nil {
+		cancel()
+	}
+	secondErr := <-errCh
+
+	logWebSocketProxyError(firstErr)
+	logWebSocketProxyError(secondErr)
+}
+
+func buildWebSocketTargetURL(targetURL string, r *http.Request) (string, error) {
+	parsedURL, err := url.Parse(targetURL)
+	if err != nil {
+		return "", fmt.Errorf("invalid target URL: %w", err)
+	}
+
+	switch parsedURL.Scheme {
+	case "https":
+		parsedURL.Scheme = "wss"
+	case "http":
+		parsedURL.Scheme = "ws"
+	case "wss", "ws":
+	default:
+		return "", fmt.Errorf("unsupported websocket target scheme: %s", parsedURL.Scheme)
+	}
+
+	if parsedURL.RawQuery == "" {
+		parsedURL.RawQuery = r.URL.RawQuery
+	}
+
+	return parsedURL.String(), nil
+}
+
+func splitHeaderTokens(values []string) []string {
+	var tokens []string
+	for _, value := range values {
+		for _, part := range strings.Split(value, ",") {
+			token := strings.TrimSpace(part)
+			if token != "" {
+				tokens = append(tokens, token)
+			}
+		}
+	}
+	return tokens
+}
+
+func relayWebSocketMessages(ctx context.Context, dst, src *websocket.Conn) error {
+	for {
+		msgType, data, err := src.Read(ctx)
+		if err != nil {
+			if status := websocket.CloseStatus(err); status != -1 {
+				_ = dst.Close(status, "")
+				return nil
+			}
+			if errors.Is(err, context.Canceled) {
+				return nil
+			}
+			_ = dst.Close(websocket.StatusInternalError, "")
+			return err
+		}
+
+		if err := dst.Write(ctx, msgType, data); err != nil {
+			if status := websocket.CloseStatus(err); status != -1 || errors.Is(err, context.Canceled) {
+				return nil
+			}
+			return err
+		}
+	}
+}
+
+func logWebSocketProxyError(err error) {
+	if err == nil || errors.Is(err, context.Canceled) || websocket.CloseStatus(err) != -1 {
+		return
+	}
+	log.Debug().Err(err).Msg("websocket proxy loop terminated")
+}

--- a/internal/gateway/models.go
+++ b/internal/gateway/models.go
@@ -2,6 +2,7 @@ package gateway
 
 import (
 	"encoding/json"
+	"io"
 	"net/http"
 	"strings"
 	"time"
@@ -23,6 +24,50 @@ type modelsResponse struct {
 	Data   []modelObject `json:"data"`
 }
 
+type codexModelObject struct {
+	Slug                     string                `json:"slug"`
+	DisplayName              string                `json:"display_name"`
+	Description              string                `json:"description"`
+	DefaultReasoningLevel    string                `json:"default_reasoning_level"`
+	SupportedReasoningLevels []codexReasoningLevel `json:"supported_reasoning_levels"`
+	ShellType                string                `json:"shell_type"`
+	Visibility               string                `json:"visibility"`
+	SupportedInAPI           bool                  `json:"supported_in_api"`
+	Priority                 int                   `json:"priority"`
+	AvailabilityNUX          any                   `json:"availability_nux"`
+	Upgrade                  any                   `json:"upgrade"`
+	BaseInstructions         string                `json:"base_instructions"`
+	SupportsReasoningSummary bool                  `json:"supports_reasoning_summaries"`
+	SupportVerbosity         bool                  `json:"support_verbosity"`
+	DefaultVerbosity         any                   `json:"default_verbosity"`
+	ApplyPatchToolType       any                   `json:"apply_patch_tool_type"`
+	TruncationPolicy         codexTruncationPolicy `json:"truncation_policy"`
+	SupportsParallelTools    bool                  `json:"supports_parallel_tool_calls"`
+	SupportsImageDetail      bool                  `json:"supports_image_detail_original"`
+	ContextWindow            int                   `json:"context_window"`
+	ExperimentalTools        []string              `json:"experimental_supported_tools"`
+	PreferWebSockets         bool                  `json:"prefer_websockets"`
+}
+
+type codexReasoningLevel struct {
+	Effort      string `json:"effort"`
+	Description string `json:"description"`
+}
+
+type codexTruncationPolicy struct {
+	Mode  string `json:"mode"`
+	Limit int    `json:"limit"`
+}
+
+type codexModelsResponse struct {
+	Models []codexModelObject `json:"models"`
+}
+
+func (g *Gateway) registerModelRoutes(mux *http.ServeMux) {
+	mux.HandleFunc("/models", g.handleModels)
+	mux.HandleFunc("/v1/models", g.handleModels)
+}
+
 // handleModels serves an OpenAI-compatible model list from the pricing table.
 func (g *Gateway) handleModels(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodGet {
@@ -30,26 +75,89 @@ func (g *Gateway) handleModels(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Proxy /models upstream only when the caller explicitly targets an upstream
+	// endpoint or uses provider-native API credentials. ChatGPT subscription
+	// tokens do not support /backend-api/models and must keep the local synthetic list.
+	if shouldProxyModelsUpstream(r) {
+		resp, _, err := g.forwardPassthrough(r.Context(), r, nil)
+		if err == nil && resp != nil {
+			defer func() { _ = resp.Body.Close() }()
+			responseBody, _ := io.ReadAll(io.LimitReader(resp.Body, MaxResponseSize))
+			copyHeaders(w, resp.Header)
+			w.WriteHeader(resp.StatusCode)
+			_, _ = w.Write(responseBody)
+			return
+		}
+	}
+
 	modelIDs := costcontrol.ListModels()
 	now := time.Now().Unix()
+	reasoningLevels := []codexReasoningLevel{
+		{Effort: "low", Description: "Fast responses with lighter reasoning"},
+		{Effort: "medium", Description: "Balances speed and reasoning depth for everyday tasks"},
+		{Effort: "high", Description: "Greater reasoning depth for complex problems"},
+	}
 
 	data := make([]modelObject, 0, len(modelIDs))
-	for _, id := range modelIDs {
+	codexModels := make([]codexModelObject, 0, len(modelIDs))
+	for idx, id := range modelIDs {
 		data = append(data, modelObject{
 			ID:      id,
 			Object:  "model",
 			Created: now,
 			OwnedBy: inferOwnedBy(id),
 		})
-	}
-
-	resp := modelsResponse{
-		Object: "list",
-		Data:   data,
+		codexModels = append(codexModels, codexModelObject{
+			Slug:                     id,
+			DisplayName:              id,
+			Description:              "",
+			DefaultReasoningLevel:    "medium",
+			SupportedReasoningLevels: reasoningLevels,
+			ShellType:                "shell_command",
+			Visibility:               "list",
+			SupportedInAPI:           true,
+			Priority:                 idx,
+			AvailabilityNUX:          nil,
+			Upgrade:                  nil,
+			BaseInstructions:         "",
+			SupportsReasoningSummary: false,
+			SupportVerbosity:         false,
+			DefaultVerbosity:         nil,
+			ApplyPatchToolType:       nil,
+			TruncationPolicy:         codexTruncationPolicy{Mode: "bytes", Limit: 10000},
+			SupportsParallelTools:    true,
+			SupportsImageDetail:      false,
+			ContextWindow:            272000,
+			ExperimentalTools:        []string{},
+			PreferWebSockets:         false,
+		})
 	}
 
 	w.Header().Set("Content-Type", "application/json")
-	_ = json.NewEncoder(w).Encode(resp)
+	if r.URL.Path == "/models" {
+		_ = json.NewEncoder(w).Encode(codexModelsResponse{Models: codexModels})
+		return
+	}
+
+	_ = json.NewEncoder(w).Encode(modelsResponse{
+		Object: "list",
+		Data:   data,
+	})
+}
+
+func shouldProxyModelsUpstream(r *http.Request) bool {
+	if strings.TrimSpace(r.Header.Get(HeaderTargetURL)) != "" {
+		return true
+	}
+	if auth := strings.TrimSpace(r.Header.Get("Authorization")); auth != "" && !isChatGPTSubscription(r) {
+		return true
+	}
+	for _, header := range []string{"x-api-key", "x-goog-api-key", "api-key", "anthropic-version"} {
+		if strings.TrimSpace(r.Header.Get(header)) != "" {
+			return true
+		}
+	}
+	return false
 }
 
 // inferOwnedBy returns the provider name based on model ID prefix.


### PR DESCRIPTION
> This PR, including the code changes and this description, was generated entirely by Codex.

## What and why

This PR makes local `Context-Gateway` compatible with the Codex startup path when the CLI is launched through `OPENAI_BASE_URL` and runs without the `Compresr` backend.

There were two startup problems:
- `Codex` calls `GET /models` during startup, while the gateway either did not serve `/models` or returned an incompatible response schema.
- `Codex` prefers `WebSocket` transport on `/responses`; the gateway only handled the regular `HTTP` route, so the CLI retried several times and then fell back to `HTTPS`, adding noticeable startup latency.

The business goal of this change is a clean `Codex -> gateway -> upstream` path without startup noise on the critical path and without extra seconds of waiting before the first response.

## User scenarios

- Scenario: a user runs the gateway locally or in Docker and starts `Codex` with `OPENAI_BASE_URL=http://127.0.0.1:18081`.
  User action: runs `codex` or `codex exec`.
  System behavior: successfully serves `GET /models`, accepts `WebSocket` on `/responses`, and proxies the stream upstream without falling back to `HTTPS`.

- Scenario: a client uses `GET /v1/models` as an OpenAI-compatible route.
  User action: calls `/v1/models`.
  System behavior: continues returning an OpenAI-compatible model list.

- Scenario: a client explicitly targets a real upstream for `GET /models` through `X-Target-URL` or provider-native auth.
  User action: calls `/models` with explicit upstream context.
  System behavior: proxies `GET /models` upstream without rewriting the schema.

## How it is implemented

- Added a `/models` alias next to the existing `/v1/models` route.
- Added a synthetic Codex-compatible `ModelsResponse` for `/models`, built against Codex's own schema (`models: [...]` with required fields such as `display_name`, `supported_reasoning_levels`, `truncation_policy`, etc.).
- Kept `/models` local for ChatGPT subscription tokens because `chatgpt.com/backend-api/models` does not provide the contract Codex expects.
- Extracted shared `resolveTargetURL` logic so regular passthrough and websocket proxying use the same upstream resolution path.
- Updated `forwardPassthrough` to preserve the original HTTP method instead of forcing `POST`.
- Added a `WebSocket` bridge for upgrade requests: the gateway accepts the client websocket, opens an upstream websocket, and relays messages bidirectionally.
- Added tests for:
  - `/models` alias registration
  - `/models` and `/v1/models` response behavior
  - explicit upstream proxying for `GET /models`
  - websocket proxying for `/responses`

## Validation

Executed:
- `go test ./internal/gateway ./tests/gateway/unit/...`
- `docker compose -f /Users/deniszabozhanov/dev/_scratch/context-gateway-codex-local-20260314/docker-compose.yml up -d --build`
- `OPENAI_BASE_URL=http://127.0.0.1:18081 codex exec "Reply with exactly one word: pong"`

Manual outcome:
- `Codex` responds through the gateway
- `/models` decode errors are gone
- `WebSocket -> HTTPS` fallback is gone
- startup latency caused by the websocket retry loop is gone

## Risks and limits

- The synthetic `/models` payload uses the minimum valid Codex-compatible contract rather than a full upstream catalog with provider-specific metadata.
- The change is intentionally focused on the Codex startup path; `/v1/models` remains OpenAI-compatible, and `/models` becomes Codex-compatible for this proxy scenario.
