### PR TITLE
Forward Claude Code first-party identification headers (User-Agent, X-Stainless-*, etc.)

### DIFF
--- a/internal/gateway/handler.go
+++ b/internal/gateway/handler.go
@@ -1043,6 +1043,15 @@ func (g *Gateway) forwardPassthrough(ctx context.Context, r *http.Request, body 
 				// Codex CLI headers (required for ChatGPT subscription)
 				"Chatgpt-Account-Id", "Originator", "Session_id", "Version",
 				"X-Codex-Turn-Metadata", "Accept",
+				// Claude Code first-party identification headers — Anthropic API uses these
+				// to recognize legitimate CLI clients and grant subscription entitlements
+				// (e.g. context-1m-2025-08-07 beta). Without them, Anthropic returns 429
+				// for betas that are only available to authenticated Claude Code subscribers.
+				"User-Agent", "X-App", "Anthropic-Dangerous-Direct-Browser-Access",
+				"X-Claude-Code-Session-Id",
+				"X-Stainless-Arch", "X-Stainless-Lang", "X-Stainless-Os",
+				"X-Stainless-Package-Version", "X-Stainless-Retry-Count",
+				"X-Stainless-Runtime", "X-Stainless-Runtime-Version", "X-Stainless-Timeout",
 			} {
 				if v := r.Header.Get(h); v != "" {
 					httpReq.Header.Set(h, v)


### PR DESCRIPTION
## Problem

The HTTP header whitelist in `forwardPassthrough` (handler.go:1037-1046) drops the headers that identify the request as coming from a legitimate Claude Code CLI client:

- `User-Agent: claude-cli/...`
- `X-App: cli`
- `Anthropic-Dangerous-Direct-Browser-Access: true`
- `X-Claude-Code-Session-Id`
- `X-Stainless-*` (the Anthropic SDK identification family)

Anthropic's API uses these headers to recognize first-party Claude Code clients and grant the subscription-based entitlements that ship with Claude Pro/Max — including the `context-1m-2025-08-07` beta. When these headers are stripped, Anthropic responds with **HTTP 429** and the user-visible error *"Extra usage is required for 1M context"* for any request that carries the long-context beta on Sonnet 4.6 or Haiku 4.5, even though the user's subscription does grant that entitlement when going direct.

## Reproduction

1. Point Claude Code at a gateway in `passthrough` mode (`ANTHROPIC_BASE_URL=http://localhost:18080`).
2. Use the CLI with a Claude Pro/Max subscription on `claude-sonnet-4-6` or `claude-haiku-4-5`.
3. Send any request whose `Anthropic-Beta` header includes `context-1m-2025-08-07` — Anthropic returns 429.
4. Disable the gateway (point CLI directly at `api.anthropic.com`) → same request, same model, **succeeds**.

We initially suspected this was tied to session size (since CLI behavior may add the `context-1m` beta opportunistically), but the failure also reproduces on a freshly cleared, otherwise empty Claude Code session. The trigger is the presence of the beta on a non-identified client, not the request payload size.

## Fix

Add the missing first-party identification headers to the forwarded list in `forwardPassthrough`. This restores parity between direct and gateway-mediated requests.

Empirically verified on `claude-sonnet-4-6`: with this patch, the previously-failing 429 returns 200 OK and the conversation continues normally.

## Caveat on the fix scope

I did not isolate which specific header among those added is the one that actually triggers Anthropic to grant the entitlement. They were added as a batch — every header that Claude Code CLI sends and the previous whitelist dropped. The empirical test confirmed that the **set as a whole** fixes the 429, but I have not bisected to determine the minimal subset.

The most likely candidates based on what Anthropic's API tends to inspect are `User-Agent: claude-cli/...`, `Anthropic-Dangerous-Direct-Browser-Access: true`, and the `X-Stainless-*` family (since Stainless is the SDK Anthropic ships). But I have no proof — could be just one of them, could be a combination. Worth narrowing down later if anyone wants to keep the whitelist tight.

## Note on completeness

This is the minimal fix. A more thorough rework would replace the whitelist with a denylist of hop-by-hop headers per RFC 7230 §6.1, which is the standard reverse-proxy pattern and would avoid future bugs of the same shape (e.g. when Anthropic introduces another identification header). I kept the change minimal here to match the surrounding style; happy to follow up with a denylist refactor in a separate PR if maintainers prefer.
